### PR TITLE
2.7 fetch empty staging table

### DIFF
--- a/pycarol/staging.py
+++ b/pycarol/staging.py
@@ -347,6 +347,8 @@ class Staging:
             s3 = carolina.s3
             d = _import_pandas(s3=s3, tenant_id=self.carol.tenant['mdmId'], connector_id=connector_id, verbose=verbose,
                                staging_name=staging_name, n_jobs=n_jobs, golden=False, columns=columns, max_hits=max_hits)
+
+            #TODO: Do the same for dask backend
             if d is None:
                 warnings.warn(f'No data to fetch! {staging_name} has no data', UserWarning)
                 cols_keys = list(self.get_schema(


### PR DESCRIPTION
Create empty data frame in cases where the staging tables are empty and update their column types in order to maintain the type according to schema.