### PR TITLE
callback discussion. 

### DIFF
--- a/pycarol/staging.py
+++ b/pycarol/staging.py
@@ -278,7 +278,7 @@ class Staging:
 
     def fetch_parquet(self, staging_name, connector_id=None, connector_name=None, backend='dask',verbose=0,
                       merge_records=True, n_jobs=1, return_dask_graph=False, columns=None, max_hits=None,
-                      return_metadata=False):
+                      return_metadata=False, callback=None):
         """
 
         Fetch parquet from a staging table.
@@ -350,7 +350,8 @@ class Staging:
         elif backend=='pandas':
             s3 = carolina.s3
             d = _import_pandas(s3=s3, tenant_id=self.carol.tenant['mdmId'], connector_id=connector_id, verbose=verbose,
-                               staging_name=staging_name, n_jobs=n_jobs, golden=False, columns=columns, max_hits=max_hits)
+                               staging_name=staging_name, n_jobs=n_jobs, golden=False, columns=columns,
+                               max_hits=max_hits, callback=callback)
 
             #TODO: Do the same for dask backend
             if d is None:


### PR DESCRIPTION
Goal:
Filter parquet when downloading. 

This is a POC I am doing, created the pull request to see what you guys think.  

About the problem
A nice thing about ES is that we could download the data already filtered. The problem we know is too slow to download from ES. With parquet it is faster to download everything and then filte. The problem I am facing is that for the supermarket project I have to do a filter where I need only 800k records from the 10kk in the staging. From this first filter, I could filter a second staging that has about 80kk records. To download all the data and then filter I need a huge machine. With this callback, I can enter the filter and only keep the data I need. 

This implementation is very slow, but still, I see value on that. What do you guys think?

