### PR TITLE
allow to use the auth connector

### DIFF
--- a/pycarol/auth/PwdAuth.py
+++ b/pycarol/auth/PwdAuth.py
@@ -9,6 +9,7 @@ class PwdAuth:
         self.password = password
         self._token = None
         self.carol = None
+        self.connector_id = None
 
     def set_connector_id(self, connector_id):
         self.connector_id = connector_id

--- a/pycarol/carol.py
+++ b/pycarol/carol.py
@@ -79,16 +79,16 @@ class Carol:
 
                 auth = ApiKeyAuth(auth_token)
 
-
         if connector_id is None:
-            connector_id = __CONNECTOR_PYCAROL__
-
+            if auth.connector_id is None:
+                connector_id = __CONNECTOR_PYCAROL__
+            else:
+                connector_id = auth.connector_id
 
         if domain is None or app_name is None or auth is None:
-            raise ValueError("domain, app_name and auth must be specified as parameters, in the app_config.json file " +
-                             "or in the environment variables CAROLTENANT, CAROLAPPNAME, CAROLAPPOAUTH" +
-                             " OR CAROLUSER+CAROLPWD and " +
-                             "CAROLCONNECTORID")
+            raise ValueError("domain, app_name and auth must be specified as parameters, either " +
+                             "in the environment variables CAROLTENANT, CAROLAPPNAME, CAROLAPPOAUTH" +
+                             " or CAROLUSER+CAROLPWD and  CAROLCONNECTORID")
 
         # TODO Fixed to be compatible with the old `ENV_DOMAIN`. We could add a deprecated warning.
         self.environment = os.getenv('CAROL_DOMAIN', os.getenv('ENV_DOMAIN', environment))


### PR DESCRIPTION
this was not working.

```python

api_key = ApiKeyAuth(key)
api_key.set_connector_id(conn)

carol = Carol('grupoebdhml', 'winthor', auth=api_key, environment='carol.ai')
carolina  = Carolina(carol)
carolina.init_if_needed()

```

```
xception: ('{"applicationErrorCode":null,"errorCode":400,"errorMessage":"apiKey and connectorId pair is invalid.","notFound":false,"possibleResponsibleField":""}', 400)
```

it was getting the pycarol connector. 