### PR TITLE
fix: package order for releasing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ help:
 	@echo "  docs	create pydocs for all relveant modules"
 	@echo "	 test	run all tests with coverage"
 
-ci: setup clean package sonar
+ci: setup sonar
 
 setup:
 	@./hack/setup.sh
@@ -41,7 +41,7 @@ dev:
 docs:
 	$(MAKE) -C docs html
 
-package:
+package: clean
 	@echo "~~~ Packaging pyCarol"
 	@python3 setup.py sdist
 	@python3 setup.py bdist_wheel

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -10,7 +10,7 @@ test -n "${BUILDKITE_TAG}" && {
 	git checkout "tags/${BUILDKITE_TAG}"
 
 	# push the package to pypi
-	make deploy
+	make package deploy
 
 	# this is required as we need the desired version on pypi for
 	# docker image that will fetch the image from there


### PR DESCRIPTION
We need to package the pyCarol prior the deployment on PyPI, and not during the build.