### PR TITLE
fix: shorter name on buildkite desc

### DIFF
--- a/.buildkite/pipeline.sh
+++ b/.buildkite/pipeline.sh
@@ -3,13 +3,13 @@ set -e
 
 cat <<EOF
 steps:
-  - label: ":python: Configuring, Packaging, Testing and Scanning"
+  - label: ":python: build"
     command: make ci
     agents:
       queue: "default"
     timeout_in_minutes: 10
   - wait: ~
-  - label: ":python: Releasing the Package and Image"
+  - label: ":python: release"
     command: make release
     branches: "*.*.*"
     agents:


### PR DESCRIPTION
Descriptions created this kind of check on GitHub: `buildkite/pycarol/python-configuring-packaging-testing-and-scannin`, let's just use short names: `buildkite/pycarol/python-build` and `buildkite/pycarol/python-release`