### PR TITLE
Switch context feature. 

### DIFF
--- a/pycarol/auth/ApiKeyAuth.py
+++ b/pycarol/auth/ApiKeyAuth.py
@@ -22,11 +22,11 @@ class ApiKeyAuth:
         headers['x-auth-connectorid'] = self.connector_id
 
     def switch_context(self, env_id):
-
         """
+        Switch context to an environment within the same organization.
 
         Args:
-            env_id: enviroment id to switch context to.
+            env_id: environment id to switch context to.
 
         Returns:
             None
@@ -39,5 +39,19 @@ class ApiKeyAuth:
         self.api_key = resp['apiKey']
         self.connector_id = resp['connectorId']
 
+    def switch_org_context(self, org_id):
+        """
+        Go to the organization context.
+
+        Args:
+            org_id: organization id.
+
+        Returns:
+            NotImplemented. This feature does not work for `ApiKeyAuth`
+
+        """
+
+        raise NotImplemented("Switch context using `ApiKeyAuth` "
+                             "is not available")
 
 

--- a/pycarol/auth/ApiKeyAuth.py
+++ b/pycarol/auth/ApiKeyAuth.py
@@ -23,6 +23,16 @@ class ApiKeyAuth:
 
     def switch_context(self, env_id):
 
+        """
+
+        Args:
+            env_id: enviroment id to switch context to.
+
+        Returns:
+            None
+
+        """
+
         path = f'v2/oauth2/switchTenantContextWithApiKey/{env_id}'
         resp = self.carol.call_api(method='POST', path=path)
 

--- a/pycarol/auth/ApiKeyAuth.py
+++ b/pycarol/auth/ApiKeyAuth.py
@@ -20,3 +20,14 @@ class ApiKeyAuth:
     def authenticate_request(self, headers):
         headers['x-auth-key'] = self.api_key
         headers['x-auth-connectorid'] = self.connector_id
+
+    def switch_context(self, env_id):
+
+        path = f'v2/oauth2/switchTenantContextWithApiKey/{env_id}'
+        resp = self.carol.call_api(method='POST', path=path)
+
+        self.api_key = resp['apiKey']
+        self.connector_id = resp['connectorId']
+
+
+

--- a/pycarol/auth/ApiKeyAuth.py
+++ b/pycarol/auth/ApiKeyAuth.py
@@ -41,17 +41,20 @@ class ApiKeyAuth:
 
     def switch_org_context(self, org_id):
         """
-        Go to the organization context.
+        Go to the organization context or switch organization.
 
         Args:
             org_id: organization id.
 
         Returns:
-            NotImplemented. This feature does not work for `ApiKeyAuth`
+            None
 
         """
 
-        raise NotImplemented("Switch context using `ApiKeyAuth` "
-                             "is not available")
+        path = f'v2/oauth2/switchOrgContext/{org_id}'
+        resp = self.carol.call_api(method='POST', path=path)
+
+        self.api_key = resp['apiKey']
+        self.connector_id = resp['connectorId']
 
 

--- a/pycarol/auth/PwdAuth.py
+++ b/pycarol/auth/PwdAuth.py
@@ -96,7 +96,7 @@ class PwdAuth:
 
     def switch_org_context(self, org_id):
         """
-        Go to the organization context.
+        Go to the organization context or switch organization.
 
         Args:
             org_id: organization id.

--- a/pycarol/auth/PwdAuth.py
+++ b/pycarol/auth/PwdAuth.py
@@ -34,7 +34,8 @@ class PwdAuth:
         self._token = types.SimpleNamespace()
         self._token.access_token = resp['access_token']
         self._token.refresh_token = resp['refresh_token']
-        self._token.expiration = resp['timeIssuedInMillis'] + (resp['expires_in'] * 1000)
+        self._token.expiration = resp['timeIssuedInMillis'] + (
+                    resp['expires_in'] * 1000)
         if self.carol.verbose:
             print("Token: {}".format(self._token.access_token))
 
@@ -69,9 +70,20 @@ class PwdAuth:
         self._token = types.SimpleNamespace()
         self._token.access_token = resp['access_token']
         self._token.refresh_token = resp['refresh_token']
-        self._token.expiration = resp['timeIssuedInMillis'] + (resp['expires_in'] * 1000)
+        self._token.expiration = resp['timeIssuedInMillis'] \
+                                 + (resp['expires_in'] * 1000)
 
     def switch_context(self, env_id):
+        """
+        Switch context to an environment within the same organization.
+
+        Args:
+            env_id: environment id to switch context to.
+
+        Returns:
+            None
+
+        """
 
         path = f'v2/oauth2/switchTenantContext/{env_id}'
         resp = self.carol.call_api(method='POST', path=path)
@@ -79,7 +91,26 @@ class PwdAuth:
         self._token = types.SimpleNamespace()
         self._token.access_token = resp['access_token']
         self._token.refresh_token = resp['refresh_token']
-        self._token.expiration = resp['timeIssuedInMillis'] + (resp['expires_in'] * 1000)
+        self._token.expiration = resp['timeIssuedInMillis'] \
+                                 + (resp['expires_in'] * 1000)
 
+    def switch_org_context(self, org_id):
+        """
+        Go to the organization context.
 
+        Args:
+            org_id: organization id.
 
+        Returns:
+            None
+
+        """
+
+        path = f'v2/oauth2/switchOrgContext/{org_id}'
+        resp = self.carol.call_api(method='POST', path=path)
+
+        self._token = types.SimpleNamespace()
+        self._token.access_token = resp['access_token']
+        self._token.refresh_token = resp['refresh_token']
+        self._token.expiration = resp['timeIssuedInMillis'] + (
+                resp['expires_in'] * 1000)

--- a/pycarol/auth/PwdAuth.py
+++ b/pycarol/auth/PwdAuth.py
@@ -70,3 +70,16 @@ class PwdAuth:
         self._token.access_token = resp['access_token']
         self._token.refresh_token = resp['refresh_token']
         self._token.expiration = resp['timeIssuedInMillis'] + (resp['expires_in'] * 1000)
+
+    def switch_context(self, env_id):
+
+        path = f'v2/oauth2/switchTenantContext/{env_id}'
+        resp = self.carol.call_api(method='POST', path=path)
+
+        self._token = types.SimpleNamespace()
+        self._token.access_token = resp['access_token']
+        self._token.refresh_token = resp['refresh_token']
+        self._token.expiration = resp['timeIssuedInMillis'] + (resp['expires_in'] * 1000)
+
+
+

--- a/pycarol/carol.py
+++ b/pycarol/carol.py
@@ -13,11 +13,9 @@ from . organization import Organization
 
 
 class Carol:
-
     """
     This class handle all Carol`s API calls It will handle all API calls,
     for a given authentication method. :param domain: `str`.
-
 
     Args:
 
@@ -165,7 +163,6 @@ class Carol:
         """
         Static method used to handle retries between calls.
 
-
         Args:
 
             retries: `int` , default `5`
@@ -207,7 +204,6 @@ class Carol:
                  **kwds):
         """
         This method handles all the API calls.
-
 
         Args:
 
@@ -323,7 +319,6 @@ class Carol:
 
     def issue_api_key(self):
         """
-
         Create an API key for a given connector.
 
         Returns: `dict`
@@ -338,10 +333,10 @@ class Carol:
     def api_key_details(self, api_key, connector_id):
 
         """
-
         Display information about the API key.
 
         Args:
+
             api_key: `str`
                 Carol's api key
             connector_id: `str`
@@ -358,10 +353,8 @@ class Carol:
         return resp
 
     def api_key_revoke(self, connector_id):
-
         """
         Revoke API key for ta given connector_id
-
 
         Args:
 
@@ -449,7 +442,6 @@ class Carol:
     def switch_context(self, env_name=None, env_id=None, app_name=None):
         """
         Context manager to temporary have access to a second environment
-
 
         Args:
 

--- a/pycarol/carol.py
+++ b/pycarol/carol.py
@@ -398,10 +398,11 @@ class Carol:
         Args:
             env_name: `str` default `None`
                 Environment (tenant) name to switch the context to.
-            env_id:
+            env_id: `str` default `None`
                 Environment (tenant) id to switch the context to.
-            app_name:
+            app_name: `str` default `None`
                 App name in the target environment to switch the context to.
+                Only needed with using CDS.
 
         Returns:
             None

--- a/pycarol/carol.py
+++ b/pycarol/carol.py
@@ -393,6 +393,20 @@ class Carol:
 
 
     def switch_context(self, env_name=None, env_id=None, app_name=None):
+        """
+
+        Args:
+            env_name: `str` default `None`
+                Environment (tenant) name to switch the context to.
+            env_id:
+                Environment (tenant) id to switch the context to.
+            app_name:
+                App name in the target environment to switch the context to.
+
+        Returns:
+            None
+
+        """
 
         if self.org is None:
             self.org = Organization(self).get_organization_info(self.organization)

--- a/pycarol/carol.py
+++ b/pycarol/carol.py
@@ -9,6 +9,7 @@ from .auth.PwdAuth import PwdAuth
 from .tenant import Tenant
 from . import __CONNECTOR_PYCAROL__
 from . import __version__
+from . organization import Organization
 
 
 class Carol:
@@ -119,6 +120,8 @@ class Carol:
         self.auth.set_connector_id(self.connector_id)
         self.auth.login(self)
         self.response = None
+
+        self.org = None
 
 
     @staticmethod
@@ -387,3 +390,21 @@ class Carol:
             print("Copied API Key to clipboard: " + token)
         else:
             raise Exception("Auth object not set. Can't fetch token.")
+
+
+    def switch_context(self, env_name=None, env_id=None, app_name=None):
+
+        if self.org is None:
+            self.org = Organization(self).get_organization_info(self.organization)
+
+        if env_name:
+            env_id = Tenant(self).get_tenant_by_domain(env_name)['mdmId']
+        elif env_id is None:
+            raise ValueError('Either `env_name` or `env_id` must be set.')
+
+        self.auth.switch_context(env_id=env_id)
+
+        self.organization = self.org['mdmSubdomain']
+        self.domain = env_name
+        self.app_name = app_name #TODO: Today we cannot use CDS without a valid app name.
+        self.tenant = Tenant(self).get_tenant_by_domain(env_name)

--- a/pycarol/carol.py
+++ b/pycarol/carol.py
@@ -20,6 +20,7 @@ class Carol:
 
 
     Args:
+
         domain: `str`. default `None`.
             Tenant name. e.x., domain.carol.ai
         app_name: `str`. default `None`.
@@ -130,6 +131,7 @@ class Carol:
         Set the host to be used.
 
         Args:
+
             domain: `str`
                 Former tenant name.
                 e.x., domain.carol.ai
@@ -165,6 +167,7 @@ class Carol:
 
 
         Args:
+
             retries: `int` , default `5`
                 Number of retries for the API calls
             session: Session object dealt `None`
@@ -207,6 +210,7 @@ class Carol:
 
 
         Args:
+
             path: `str`.
                 API URI path. e.x.  v2/staging/schema
             method: 'str', default `None`.
@@ -411,8 +415,18 @@ class Carol:
                 Only needed with using CDS.
 
         Returns:
-
             self
+
+        .. code:: python
+
+            from pycarol import Carol, Staging
+            carol = Carol('B', 'teste', auth=PwdAuth('email@totvs.com.br', 'pass'), )
+            carol.switch_environment('A')
+            Staging(carol_tenant_A).fetch_parquet(...) # fetch parquet from tenant A
+            # To switch back
+            carol.switch_environment('B')
+            #back to tenant B
+
 
         """
 
@@ -449,6 +463,17 @@ class Carol:
 
         Returns:
             None
+
+        Usage:
+
+        .. code:: python
+
+            from pycarol import Carol, Staging
+            carol = Carol('B', 'teste', auth=PwdAuth('email@totvs.com.br', 'pass'), )
+            with carol.switch_context('A') as carol_tenant_A:
+                Staging(carol_tenant_A).fetch_parquet(...) # fetch parquet from tenant A
+            #back to tenant B
+
 
         """
 

--- a/pycarol/organization.py
+++ b/pycarol/organization.py
@@ -1,0 +1,37 @@
+
+
+class Organization:
+
+    def __init__(self, carol):
+        self.carol = carol
+
+    def get_organization_info(self, subdomain):
+        """
+        Get organization information.
+
+        :param subdomain: `str`
+            Organization subdomain
+        :return:
+            dict with the information about the organization.
+        """
+
+        return self.carol.call_api(f'v1/organizations/domain/{subdomain}',
+                                   auth=False, status_forcelist=[], retries=0)
+
+
+    def get_environment_info(self, environment):
+        """
+        Get environment information.
+
+        :param environment: `str`
+            Tenant name
+        :return:
+            dict with the information about the environment.
+        """
+        return self.carol.call_api(f'v2/tenants/domain/{environment}',
+                                   auth=False, status_forcelist=[], retries=0)
+
+
+
+
+

--- a/pycarol/organization.py
+++ b/pycarol/organization.py
@@ -35,14 +35,3 @@ class Organization:
 
         return self.carol.call_api(f'v1/organizations/{org_id}/allTenants',
                                    auth=False, status_forcelist=[], retries=0)
-
-
-
-
-
-
-
-
-
-
-

--- a/pycarol/organization.py
+++ b/pycarol/organization.py
@@ -1,8 +1,17 @@
 
 
 class Organization:
+    """
+    Get organization information.
+
+    Args:
+
+        Carol object
+            Carol object.
+    """
 
     def __init__(self, carol):
+
         self.carol = carol
 
     def get_organization_info(self, organization):
@@ -33,5 +42,6 @@ class Organization:
 
     def all_tenants(self, org_id=None, org_name=None):
 
+        raise NotImplemented
         return self.carol.call_api(f'v1/organizations/{org_id}/allTenants',
                                    auth=False, status_forcelist=[], retries=0)

--- a/pycarol/organization.py
+++ b/pycarol/organization.py
@@ -5,17 +5,17 @@ class Organization:
     def __init__(self, carol):
         self.carol = carol
 
-    def get_organization_info(self, subdomain):
+    def get_organization_info(self, organization):
         """
         Get organization information.
 
-        :param subdomain: `str`
+        :param organization: `str`
             Organization subdomain
         :return:
             dict with the information about the organization.
         """
 
-        return self.carol.call_api(f'v1/organizations/domain/{subdomain}',
+        return self.carol.call_api(f'v1/organizations/domain/{organization}',
                                    auth=False, status_forcelist=[], retries=0)
 
 
@@ -30,6 +30,17 @@ class Organization:
         """
         return self.carol.call_api(f'v2/tenants/domain/{environment}',
                                    auth=False, status_forcelist=[], retries=0)
+
+    def all_tenants(self, org_id=None, org_name=None):
+
+        return self.carol.call_api(f'v1/organizations/{org_id}/allTenants',
+                                   auth=False, status_forcelist=[], retries=0)
+
+
+
+
+
+
 
 
 

--- a/pycarol/organization.py
+++ b/pycarol/organization.py
@@ -39,9 +39,3 @@ class Organization:
         """
         return self.carol.call_api(f'v2/tenants/domain/{environment}',
                                    auth=False, status_forcelist=[], retries=0)
-
-    def all_tenants(self, org_id=None, org_name=None):
-
-        raise NotImplemented
-        return self.carol.call_api(f'v1/organizations/{org_id}/allTenants',
-                                   auth=False, status_forcelist=[], retries=0)


### PR DESCRIPTION
#### Please provide details about this Pull Request (why the change is being made, what this commit will do):
New feature. This allows the user to change the context of the Carol instance. It means that it is possible to get data from the environment A being in environment B. This only works if the user has access to that environment. 

Context: 
When we are running a carol app, all the credentials come from environment variables. Credentials for that app. An App can have multiples data sources in different environments.

During runtime, i don't have access to the credentials for those data sources. Either I add to the code this credentials, or I get from somewhere. With Carol's organizations, we can do this switch using APIs.

----

I have two implementations for that. 
1. channging the context from B to A. 
```python
carol = Carol('B', 'teste', auth=PwdAuth('email@totvs.com.br', 'pass'),  )
carol.switch_environment('A')
#now carol is instance of Tenant A
# switching back
carol.switch_environment('B')
```
or using context manager, where the switch only happens inside the contect manager.

```python
carol = Carol('B', 'teste', auth=PwdAuth('email@totvs.com.br', 'pass'), )
with carol.switch_context('onboarding') as A:
    .... #in tenant A
#back to tenant B
````

For the `PwdAuth` this does not make much sense. Since the password is the same for the same organization, but the ApiKey is different. So, I can do 

```python
carol = Carol('B', 'teste', auth=ApiKeyAuth(key),)
carol.switch_environment('A')
```
   
or

```python
carol = Carol('B', 'teste', auth=ApiKeyAuth(key),)
with carol.switch_context('onboarding') as A:
    .... #in tenant A
#back to tenant B
```


I will not support switch organizations until a case is presented. There are some caveats for this kind of change. 