### PR TITLE
Add setup during release.

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -10,7 +10,7 @@ test -n "${BUILDKITE_TAG}" && {
 	git checkout "tags/${BUILDKITE_TAG}"
 
 	# push the package to pypi
-	make package deploy
+	make setup package deploy
 
 	# this is required as we need the desired version on pypi for
 	# docker image that will fetch the image from there


### PR DESCRIPTION
#### Please provide details about this Pull Request (why the change is being made, what this commit will do):
Deploy error

```

$ trap 'kill -- $$' INT TERM QUIT; make release
--
  | HEAD is now at aada3dc Merge remote-tracking branch 'origin/master'
  | make[1]: Entering directory '/buildkite/builds/bk-default-agent-97kzb-txnm6-1/totvslabs/pycarol'
  | Packaging pyCarol | 0s
  | Traceback (most recent call last):
  | File "setup.py", line 1, in <module>
  | from distutils.core import setup
  | ModuleNotFoundError: No module named 'distutils.core'
  | Makefile:45: recipe for target 'package' failed
  | make[1]: *** [package] Error 1
  | make[1]: Leaving directory '/buildkite/builds/bk-default-agent-97kzb-txnm6-1/totvslabs/pycarol'
  | Makefile:21: recipe for target 'release' failed
  | make: *** [release] Error 2

```

#### Please provide links to relevant Trello cards, Slab topics or support ticket:
