### PR TITLE
Metadata fetch parquet

### DIFF
--- a/pycarol/__init__.py
+++ b/pycarol/__init__.py
@@ -14,9 +14,11 @@ __CONNECTOR_PYCAROL__ = 'f9953f6645f449baaccd16ab462f9b64'
 _CAROL_METADATA_STAGING = ['mdmCounterForEntity', 'mdmId', 'mdmLastUpdated',
                            'mdmConnectorId', 'mdmDeleted']
 
-_CAROL_METADATA_GOLDEN = ['mdmCounterForEntity', 'mdmId', 'mdmCreated', 'mdmLastUpdated',
-                          'mdmTenantId', 'mdmEntityType', 'mdmSourceEntityNames', 'mdmCrosswalk',
-                          'mdmApplicationIdMasterRecordId','mdmDeleted']
+_CAROL_METADATA_GOLDEN = ['mdmApplicationIdMasterRecordId', 'mdmCounterForEntity', 'mdmCreated',  'mdmCrosswalk',
+                          'mdmDeleted', 'mdmEntityType',  'mdmId',  'mdmLastUpdated', 'mdmSourceEntityNames',
+                          'mdmStagingRecord', 'mdmTenantId']
+
+_NEEDED_FOR_MERGE = ['mdmCounterForEntity', 'mdmId', 'mdmDeleted']
 
 from .carol import Carol
 from .staging import Staging

--- a/pycarol/data_models/data_models.py
+++ b/pycarol/data_models/data_models.py
@@ -137,7 +137,7 @@ class DataModel:
 
         _diff_cols = set(columns) - set(all_cols)
         if len(_diff_cols) > 0:
-            warnings.warn(f"It seems was passed columns not in this data model {_diff_cols}", UserWarning)
+            warnings.warn(f"It seems there was used columns not in this data model: {_diff_cols}", UserWarning)
 
         if return_dask_graph:
             assert backend == 'dask'

--- a/pycarol/data_models/data_models.py
+++ b/pycarol/data_models/data_models.py
@@ -115,7 +115,7 @@ class DataModel:
             :return:
             """
 
-        if backend != 'dask' or backend != 'pandas':
+        if backend not in ['dask', 'pandas']:
             raise ValueError(f"`backend` should be either `dask` or `pandas`. It was passed {backend}")
 
         if return_metadata:

--- a/pycarol/data_models/data_models.py
+++ b/pycarol/data_models/data_models.py
@@ -132,12 +132,12 @@ class DataModel:
         if not columns:  # if an empty list was sent.
             columns = all_cols
 
-        if isinstance(columns, str):
+        elif isinstance(columns, str):
             columns = [columns]
 
-            _diff_cols = set(columns) - set(all_cols)
-            if len(_diff_cols) > 0:
-                warnings.warn(f"It seems was passed columns not in this datamodel {_diff_cols}", UserWarning)
+        _diff_cols = set(columns) - set(all_cols)
+        if len(_diff_cols) > 0:
+            warnings.warn(f"It seems was passed columns not in this data model {_diff_cols}", UserWarning)
 
         if return_dask_graph:
             assert backend == 'dask'

--- a/pycarol/data_models/data_models.py
+++ b/pycarol/data_models/data_models.py
@@ -78,7 +78,7 @@ class DataModel:
     def fetch_parquet(self, dm_name, merge_records=True, backend='pandas',
                       return_dask_graph=False,
                       columns=None, return_metadata=False, callback=None,
-                      max_hits=None, cds=False, max_workers=None, file_pattern=None,
+                      max_hits=None, cds=True, max_workers=None, file_pattern=None,
                       return_callback_result=False):
 
         """

--- a/pycarol/data_models/data_models.py
+++ b/pycarol/data_models/data_models.py
@@ -115,7 +115,7 @@ class DataModel:
             :return:
             """
 
-        if backend == 'dask' or backend == 'pandas':
+        if backend != 'dask' or backend != 'pandas':
             raise ValueError(f"`backend` should be either `dask` or `pandas`. It was passed {backend}")
 
         if return_metadata:

--- a/pycarol/data_models/data_models.py
+++ b/pycarol/data_models/data_models.py
@@ -20,7 +20,7 @@ from ..filter import TYPE_FILTER, Filter, MAXIMUM, MINIMUM
 from ..utils.miscellaneous import ranges
 from ..utils import async_helpers
 from ..utils.miscellaneous import stream_data
-from .. import _CAROL_METADATA_GOLDEN
+from .. import _CAROL_METADATA_GOLDEN, _NEEDED_FOR_MERGE
 from ..utils.miscellaneous import drop_duplicated_parquet, _deprecation_msgs
 
 _DATA_MODEL_TYPES_MAPPING = {
@@ -97,7 +97,7 @@ class DataModel:
             columns: `list`, default `None`
                 List of columns to fetch.
             return_metadata: `bool`, default `False`
-                To return or not the fields ['mdmId', 'mdmCounterForEntity']
+                To return or not the fields like ['mdmId', 'mdmCounterForEntity', etc.]
             callback: `callable`, default `None`
                 Function to be called each downloaded file.
             max_hits: `int`, default `None`
@@ -115,22 +115,32 @@ class DataModel:
             :return:
             """
 
+        if backend == 'dask' or backend == 'pandas':
+            raise ValueError(f"`backend` should be either `dask` or `pandas`. It was passed {backend}")
+
+        if return_metadata:
+            # It can be costly to get all meta from a golden. So er should alway ask for the info we want.
+            _meta_cols = _CAROL_METADATA_GOLDEN
+        else:
+            _meta_cols = _NEEDED_FOR_MERGE
+
         if callback:
             assert callable(callback), \
                 f'"{callback}" is a {type(callback)} and is not callable.'
 
+        all_cols = list(self._get_name_type_DMs(self.get_by_name(dm_name)['mdmFields']))
         if not columns:  # if an empty list was sent.
-            columns = None
+            columns = all_cols
 
         if isinstance(columns, str):
             columns = [columns]
 
-        assert backend == 'dask' or backend == 'pandas'
+            _diff_cols = set(columns) - set(all_cols)
+            if len(_diff_cols) > 0:
+                warnings.warn(f"It seems was passed columns not in this datamodel {_diff_cols}", UserWarning)
 
         if return_dask_graph:
             assert backend == 'dask'
-
-        # validate export
 
         if not cds:
 
@@ -143,7 +153,7 @@ class DataModel:
             import_type = 'golden_cds'
 
         if columns:
-            columns.extend(_CAROL_METADATA_GOLDEN)
+            columns.extend(_meta_cols)
 
         storage = Storage(self.carol)
         token_carolina = storage.backend.carolina.token
@@ -168,10 +178,10 @@ class DataModel:
                 _field_types = self._get_name_type_DMs(self.get_by_name(dm_name)['mdmFields'])
                 cols_keys = list(_field_types)
                 if return_metadata:
-                    cols_keys.extend(_CAROL_METADATA_GOLDEN)
+                    cols_keys.extend(_meta_cols)
 
                 elif columns:
-                    columns = [i for i in columns if i not in _CAROL_METADATA_GOLDEN]
+                    columns = [i for i in columns if i not in _meta_cols]
 
                 d = pd.DataFrame(columns=cols_keys)
                 for key, value in _field_types.items():
@@ -198,7 +208,7 @@ class DataModel:
                     .reset_index(drop=True)
 
         if not return_metadata:
-            to_drop = set(_CAROL_METADATA_GOLDEN).intersection(set(d.columns))
+            to_drop = set(_meta_cols).intersection(set(d.columns))
             d = d.drop(labels=to_drop, axis=1)
 
         return d

--- a/pycarol/staging.py
+++ b/pycarol/staging.py
@@ -416,7 +416,7 @@ class Staging:
             max_hits: `int`, default `None`
                 Number of records to get. This only should be user for tests.
             return_metadata: `bool`, default `False`
-                To return or not the fields ['mdmId', 'mdmCounterForEntity']
+                To return or not the fields like ['mdmId', 'mdmCounterForEntity', etc.]
             callback: `callable`, default `None`
                 Function to be called each downloaded file.
             cds: `bool`, default `True`

--- a/pycarol/staging.py
+++ b/pycarol/staging.py
@@ -12,7 +12,7 @@ from .utils.importers import _import_dask, _import_pandas
 from .filter import Filter, TYPE_FILTER
 from .utils import async_helpers
 from .utils.miscellaneous import stream_data
-from . import _CAROL_METADATA_STAGING
+from . import _CAROL_METADATA_STAGING, _NEEDED_FOR_MERGE
 from .utils.miscellaneous import drop_duplicated_parquet, _deprecation_msgs
 
 _SCHEMA_TYPES_MAPPING = {
@@ -391,7 +391,7 @@ class Staging:
 
     def fetch_parquet(self, staging_name, connector_id=None, connector_name=None, backend='pandas',
                       merge_records=True, return_dask_graph=False, columns=None, max_hits=None,
-                      return_metadata=False, callback=None, cds=False, max_workers=None, file_pattern=None,
+                      return_metadata=False, callback=None, cds=True, max_workers=None, file_pattern=None,
                       return_callback_result=False):
         """
 
@@ -419,7 +419,7 @@ class Staging:
                 To return or not the fields ['mdmId', 'mdmCounterForEntity']
             callback: `callable`, default `None`
                 Function to be called each downloaded file.
-            cds: `bool`, default `False`
+            cds: `bool`, default `True`
                 Get staging data from CDS.
             max_workers: `int` default `None`
                 Number of workers to use when downloading parquet files with pandas back-end.
@@ -434,6 +434,11 @@ class Staging:
             DataFrame with the staging data.
 
         """
+
+        if return_metadata:
+            _meta_cols = _CAROL_METADATA_STAGING
+        else:
+            _meta_cols = _NEEDED_FOR_MERGE
 
         if callback:
             assert callable(callback), \
@@ -457,7 +462,7 @@ class Staging:
             mapping_columns = list(_staging['mdmStagingMapping']['properties'].keys())
             columns = [i.replace("-", "_") for i in mapping_columns]
 
-        columns.extend(_CAROL_METADATA_STAGING)
+        columns.extend(_meta_cols)
         mapping_columns = dict(zip([i.replace("-", "_") for i in columns], mapping_columns))
 
         # TODO: Validate the code bellow for cds param
@@ -501,10 +506,10 @@ class Staging:
                 cols_keys = [i.replace("-", "_") for i in cols_keys]
 
                 if return_metadata:
-                    cols_keys.extend(_CAROL_METADATA_STAGING)
+                    cols_keys.extend(_meta_cols)
 
                 elif columns:
-                    columns = [i for i in columns if i not in _CAROL_METADATA_STAGING]
+                    columns = [i for i in columns if i not in _meta_cols]
 
                 d = pd.DataFrame(columns=cols_keys)
                 for key, value in self.get_schema(staging_name=staging_name,
@@ -532,7 +537,7 @@ class Staging:
                     .reset_index(drop=True)
 
         if not return_metadata:
-            to_drop = set(_CAROL_METADATA_STAGING).intersection(set(d.columns))
+            to_drop = set(_meta_cols).intersection(set(d.columns))
             d = d.drop(labels=to_drop, axis=1)
 
         return d


### PR DESCRIPTION
#### Please provide details about this Pull Request (why the change is being made, what this commit will do):

Now backend is saving all the staging records in the golden record as metadata. We need to filter this if the user don't want the metadata from a data model. Download all meta can increase a lot of memory consumption. 

I also add a warning to warn the user if a column not in the data model was passed. 