### PR TITLE
add support to lazy execute when using the PwdKeyAuth

### DIFF
--- a/pycarol/auth/PwdKeyAuth.py
+++ b/pycarol/auth/PwdKeyAuth.py
@@ -9,12 +9,18 @@ class PwdKeyAuth:
     Args:
         access_token: `str`
             Carol access token created using the user and password.
+        lazy_login: `bool` default `False`
+            It will not validate the `access_token` when starting the instance.
+            This is used to speedup requests, when the user knows that this token is valid. Using this option, one lose
+            all refresh token capability.
     """
-    def __init__(self, access_token):
+
+    def __init__(self, access_token, lazy_login=False):
         self.access_token = access_token
         self._token = None
         self.carol = None
         self.connector_id = None
+        self.lazy_login = lazy_login
 
     def set_connector_id(self, connector_id):
         self.connector_id = connector_id
@@ -31,6 +37,14 @@ class PwdKeyAuth:
 
         """
         self.carol = carol
+
+        if self.lazy_login:
+            self._token = types.SimpleNamespace()
+            self._token.access_token = self.access_token
+            self._token.refresh_token = None
+            self._token.expiration = float('inf')
+            return
+
 
         resp = self.carol.call_api(f'v2/oauth2/token/{self.access_token}', method='GET', auth=False,
                                    content_type='application/x-www-form-urlencoded')

--- a/pycarol/carol.py
+++ b/pycarol/carol.py
@@ -115,7 +115,7 @@ class Carol:
         self.verbose = verbose
         self.host = self._set_host(domain=self.domain, organization=self.organization,
                                    environment=self.environment, host=host)
-        self.tenant = Tenant(self).get_tenant_by_domain(domain)
+        self._tenant = None
         self.connector_id = connector_id
         self.auth = auth
         self.auth.set_connector_id(self.connector_id)
@@ -123,6 +123,13 @@ class Carol:
         self.response = None
 
         self.org = None
+
+
+    @property
+    def tenant(self):
+        if self._tenant is None:
+            self._tenant = Tenant(self).get_tenant_by_domain(self.domain)
+        return self._tenant
 
 
     @staticmethod


### PR DESCRIPTION
#### Please provide details about this Pull Request (why the change is being made, what this commit will do):

Remove the initialization of Tenant during the init of Carol instance. This is adding about `300ms`
to initiate the instance. 

@darolt requested to have a "lazy" PwdKeyToken, it means pycarol will not call Carol's API to validate the access token during the instantiation of the class. It will trust in the user access token. 
This is useful for those using pycarol in other APIs and need fast responses. 

```python
carol = Carol(tenant, 'vscode', auth=PwdKeyAuth(access_token=access_token, lazy_login=True), organization=organization)

```
