### PR TITLE
feat: More install options. 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,6 +13,19 @@ Run ``pip install pycarol`` to install the latest stable version from `PyPI
 <https://pypi.python.org/pypi/pycarol>`_. `Documentation for the latest release
 <http://pycarol.readthedocs.io/>`__ is hosted on readthedocs.
 
+This will install the minimal dependencies. To install pyCarol with the pipeline dependencies use
+``pip install pycarol[pipeline]``, or to install with dask+pipeline dependencies use ``pip install pycarol[pipeline,dask]``
+
+The options we have are: `complete`, `online`, `dask`, `pipeline`
+
+To install from source:
+1. ``pip install -r requirements.txt`` to install the minimal requirements.
+2. ``pip install -e . ".[dev]"`` to install the minimal requirements + dev libs.
+2. ``pip install -e . ".[pipeline]"`` to install the minimal requirements + pipelines dependencies.
+2. ``pip install -e . ".[dev]"`` to install the minimal requirements + dev libs.
+2. ``pip install -e . ".[complete]"`` to install all dependencies.
+
+
 Initializing pyCarol
 --------------------
 
@@ -318,5 +331,5 @@ Release process
 3. Locally, checkout to `master` branch;
 4. make bump_patch/bump_minor depending on the type of version. THis will create a commit with the new version.;
 5. Push your commit and tag;
-6. Create a new Release. 
+6. Create a new Release.
 

--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@ Run ``pip install pycarol`` to install the latest stable version from `PyPI
 This will install the minimal dependencies. To install pyCarol with the pipeline dependencies use
 ``pip install pycarol[pipeline]``, or to install with dask+pipeline dependencies use ``pip install pycarol[pipeline,dask]``
 
-The options we have are: `complete`, `online`, `dask`, `pipeline`
+The options we have are: `complete`, `onlineapp`, `dask`, `pipeline`
 
 To install from source:
 1. ``pip install -r requirements.txt`` to install the minimal requirements.

--- a/README.rst
+++ b/README.rst
@@ -13,17 +13,18 @@ Run ``pip install pycarol`` to install the latest stable version from `PyPI
 <https://pypi.python.org/pypi/pycarol>`_. `Documentation for the latest release
 <http://pycarol.readthedocs.io/>`__ is hosted on readthedocs.
 
-This will install the minimal dependencies. To install pyCarol with the pipeline dependencies use
-``pip install pycarol[pipeline]``, or to install with dask+pipeline dependencies use ``pip install pycarol[pipeline,dask]``
+This will install the minimal dependencies. To install pyCarol with the `dataframes` dependencies use
+``pip install pycarol[dataframe]``, or to install with dask+pipeline dependencies use ``pip install pycarol[pipeline,dask]``
 
-The options we have are: `complete`, `onlineapp`, `dask`, `pipeline`
+The options we have are: `complete`, `dataframe`, `onlineapp`, `dask`, `pipeline`
 
 To install from source:
-1. ``pip install -r requirements.txt`` to install the minimal requirements.
-2. ``pip install -e . ".[dev]"`` to install the minimal requirements + dev libs.
-2. ``pip install -e . ".[pipeline]"`` to install the minimal requirements + pipelines dependencies.
-2. ``pip install -e . ".[dev]"`` to install the minimal requirements + dev libs.
-2. ``pip install -e . ".[complete]"`` to install all dependencies.
+1. ``pip install -r requirements.txt`` to install the minimal requirements;
+2. ``pip install -e . ".[dev]"`` to install the minimal requirements + dev libs;
+3. ``pip install -e . ".[pipeline]"`` to install the minimal requirements + pipelines dependencies;
+4. ``pip install -e . ".[dev]"`` to install the minimal requirements + dev libs;
+5. ``pip install -e . ".[complete]"`` to install all dependencies;
+5. etc;
 
 
 Initializing pyCarol

--- a/pycarol/app/health_check_online.py
+++ b/pycarol/app/health_check_online.py
@@ -1,11 +1,7 @@
 import os
-import sys
-import urllib.parse
-import urllib.request
 
 from pycarol.tasks import Tasks
 from pycarol.carol import Carol
-from pycarol.auth.ApiKeyAuth import ApiKeyAuth
 
 
 class HealthCheckOnline():

--- a/pycarol/apps.py
+++ b/pycarol/apps.py
@@ -6,7 +6,7 @@ Carol app funtionalities.
 
 
 import zipfile, io
-from .utils.miscellaneous import _deprecation_msgs
+from .utils.deprecation_msgs import _deprecation_msgs
 
 class Apps:
     """

--- a/pycarol/cds.py
+++ b/pycarol/cds.py
@@ -8,7 +8,7 @@ the `pycarol.cds.CDSGolden` classes are used to manipulate the data inside the f
 """
 from .connectors import Connectors
 from .data_models import DataModel
-from .utils.miscellaneous import _deprecation_msgs
+from .utils.deprecation_msgs import _deprecation_msgs
 
 _MACHINE_FLAVORS = [
     'n1-standard-1',

--- a/pycarol/data_models/data_model_view.py
+++ b/pycarol/data_models/data_model_view.py
@@ -1,12 +1,9 @@
 import warnings
-import pandas as pd
 import json
 from ..utils.importers import _import_dask, _import_pandas
 from ..storage import Storage
-from ..query import Query
-from ..filter import TYPE_FILTER, Filter
-import itertools
-from ..utils.miscellaneous import drop_duplicated_parquet, _deprecation_msgs
+from ..utils.miscellaneous import drop_duplicated_parquet
+from ..utils.deprecation_msgs import _deprecation_msgs
 
 class DataModelView:
 

--- a/pycarol/data_models/data_models.py
+++ b/pycarol/data_models/data_models.py
@@ -3,7 +3,6 @@ import json
 import time
 import copy
 import warnings
-import pandas as pd
 import asyncio
 
 from .data_models_fields import DataModelFields
@@ -114,6 +113,7 @@ class DataModel:
                 operation to merge records and return selected columns.
             :return:
             """
+        import pandas as pd
 
         if backend not in ['dask', 'pandas']:
             raise ValueError(f"`backend` should be either `dask` or `pandas`. It was passed {backend}")
@@ -456,6 +456,7 @@ class DataModel:
             To use async to send the data. This is much faster than a sequential send.
         :return: None
         """
+        import pandas as pd
 
         self.gzip = gzip
         extra_headers = {}

--- a/pycarol/data_models/data_models.py
+++ b/pycarol/data_models/data_models.py
@@ -1,5 +1,4 @@
 import json
-import itertools
 
 import time
 import copy
@@ -21,7 +20,8 @@ from ..utils.miscellaneous import ranges
 from ..utils import async_helpers
 from ..utils.miscellaneous import stream_data
 from .. import _CAROL_METADATA_GOLDEN, _NEEDED_FOR_MERGE
-from ..utils.miscellaneous import drop_duplicated_parquet, _deprecation_msgs
+from ..utils.miscellaneous import drop_duplicated_parquet
+from ..utils.deprecation_msgs import _deprecation_msgs
 
 _DATA_MODEL_TYPES_MAPPING = {
     "boolean": bool,

--- a/pycarol/logger.py
+++ b/pycarol/logger.py
@@ -8,7 +8,6 @@ import os
 import logging
 import sys
 import re
-import math
 
 _carol_levels = dict(
     NOTSET="NOTSET",

--- a/pycarol/organization.py
+++ b/pycarol/organization.py
@@ -1,5 +1,3 @@
-
-
 class Organization:
     """
     Get organization information.

--- a/pycarol/query.py
+++ b/pycarol/query.py
@@ -6,9 +6,6 @@ This submodule has all the classes to query data from RT layer in Carol.
 
 import json
 import itertools
-from joblib import Parallel, delayed
-import dask
-import pandas as pd
 from datetime import datetime
 from .connectors import Connectors
 from .named_query import NamedQuery
@@ -428,7 +425,7 @@ class ParQuery:
         :param verbose:
         :param n_jobs:
         """
-
+        import pandas as pd
         self._stag_mdm_key_range = None
         self._multiplier = None
         self.carol = carol
@@ -737,6 +734,7 @@ class ParQuery:
 
 def _dask_backend(carol, chunks, datamodel_name, page_size, index_type, fields,
                   only_hits, mdm_key, return_df, fields_to_get, custom_filter):
+    import dask
     list_to_compute = []
     for RANGE_FILTER in chunks:
         y = dask.delayed(_par_query)(
@@ -759,6 +757,7 @@ def _dask_backend(carol, chunks, datamodel_name, page_size, index_type, fields,
 
 def _joblib_backend(carol, chunks, datamodel_name, page_size, index_type, fields,
                     only_hits, mdm_key, return_df, fields_to_get, custom_filter, n_jobs, verbose, ):
+    from joblib import Parallel, delayed
     list_to_compute = Parallel(n_jobs=n_jobs,
                                verbose=verbose)(delayed(_par_query)(
         datamodel_name=datamodel_name,

--- a/pycarol/schema_generator.py
+++ b/pycarol/schema_generator.py
@@ -1,7 +1,5 @@
 import json
-import numpy as np
 from datetime import datetime
-import pandas as pd
 
 class IntType(object):
     json_type = "integer"
@@ -39,6 +37,9 @@ class DateType(object):
 class Type(object):
     @classmethod
     def get_schema_type_for(cls, t):
+        import pandas as pd
+        import numpy as np
+
         """docstring for get_schema_type_for"""
 
         SCHEMA_TYPES = {

--- a/pycarol/staging.py
+++ b/pycarol/staging.py
@@ -1,19 +1,16 @@
-import pandas as pd
 import json
-import itertools
 import warnings
 import asyncio
 
-from .query import Query, delete_golden
 from .schema_generator import carolSchemaGenerator
 from .connectors import Connectors
 from .storage import Storage
 from .utils.importers import _import_dask, _import_pandas
-from .filter import Filter, TYPE_FILTER
 from .utils import async_helpers
 from .utils.miscellaneous import stream_data
 from . import _CAROL_METADATA_STAGING, _NEEDED_FOR_MERGE
-from .utils.miscellaneous import drop_duplicated_parquet, _deprecation_msgs
+from .utils.miscellaneous import drop_duplicated_parquet
+from .utils.deprecation_msgs import _deprecation_msgs
 
 _SCHEMA_TYPES_MAPPING = {
     "geopoint": str,
@@ -90,7 +87,7 @@ class Staging:
                 Send and wait data to be processed in Carol
 
         """
-
+        import pandas as pd
         if dm_to_delete is not None:
             _deprecation_msgs("`dm_to_delete` is deprecated and has no action.")
 
@@ -253,7 +250,7 @@ class Staging:
                 Data to create schema from.
 
         """
-
+        import pandas as pd
         if export_data is not None:
             _deprecation_msgs("`export_data` is deprecated and has no action.")
 
@@ -439,7 +436,7 @@ class Staging:
             DataFrame with the staging data.
 
         """
-
+        import pandas as pd
         if return_metadata:
             _meta_cols = _CAROL_METADATA_STAGING
         else:

--- a/pycarol/tenant.py
+++ b/pycarol/tenant.py
@@ -1,4 +1,4 @@
-from .utils.miscellaneous import _deprecation_msgs
+from .utils.deprecation_msgs import _deprecation_msgs
 
 
 class Tenant:

--- a/pycarol/utils/deprecation_msgs.py
+++ b/pycarol/utils/deprecation_msgs.py
@@ -1,0 +1,6 @@
+import warnings
+def _deprecation_msgs(msg):
+    warnings.warn(
+        msg,
+        DeprecationWarning, stacklevel=3
+    )

--- a/pycarol/utils/importers.py
+++ b/pycarol/utils/importers.py
@@ -1,9 +1,6 @@
-import pandas as pd
-from dask import dataframe as dd
 import multiprocessing
 import functools
 import warnings
-
 from tqdm import tqdm
 
 __STAGING_FIELDS = ['mdmCounterForEntity', 'mdmId']
@@ -14,6 +11,8 @@ def _import_dask(storage, merge_records=False,
                  dm_name=None, import_type='staging', return_dask_graph=False,
                  connector_id=None, staging_name=None, view_name=None, columns=None,
                  max_hits=None, mapping_columns=None):
+
+    from dask import dataframe as dd
     if columns:
         columns = list(set(columns))
         columns += __STAGING_FIELDS
@@ -53,6 +52,7 @@ def _import_dask(storage, merge_records=False,
 def _import_pandas(storage, dm_name=None, connector_id=None, columns=None, mapping_columns=None, max_workers=None,
                    staging_name=None, view_name=None, import_type='staging', golden=False, max_hits=None, callback=None,
                    token_carolina=None, storage_space=None,  file_pattern=None):
+    import pandas as pd
     if columns:
         columns = list(set(columns))
         columns += __DM_FIELDS
@@ -120,6 +120,7 @@ def _import_pandas(storage, dm_name=None, connector_id=None, columns=None, mappi
 
 
 def _download_files(file, storage, storage_space, columns, mapping_columns, callback):
+    import pandas as pd
     filename = storage_space +'/' + file['name']
     buffer = storage.open(filename)
     result = pd.read_parquet(buffer, columns=columns)

--- a/pycarol/utils/miscellaneous.py
+++ b/pycarol/utils/miscellaneous.py
@@ -1,17 +1,8 @@
 import json
 import gzip, io
-import pandas as pd
 from collections import defaultdict
-import numpy as np
-import warnings
 
 _FILE_MARKER = '<files>'
-
-def _deprecation_msgs(msg):
-    warnings.warn(
-        msg,
-        DeprecationWarning, stacklevel=3
-    )
 
 
 def drop_duplicated_parquet(d):
@@ -40,6 +31,7 @@ class NumpyEncoder(json.JSONEncoder):
     """ Special json encoder for numpy types """
 
     def default(self, obj):
+        import numpy as np
         if isinstance(obj, (np.int_, np.intc, np.intp, np.int8,
                             np.int16, np.int32, np.int64, np.uint8,
                             np.uint16, np.uint32, np.uint64)):
@@ -110,7 +102,7 @@ def stream_data(data, step_size, compress_gzip):
     :return: Generator, cont
         Return a slice of `data` and the count of records until that moment.
     """
-
+    import pandas as pd
     if isinstance(data, pd.DataFrame):
         is_df = True
     else:

--- a/pycarol/utils/storage_gcpcs.py
+++ b/pycarol/utils/storage_gcpcs.py
@@ -1,7 +1,6 @@
 import os
 import pickle
 import gzip
-import pandas as pd
 from .. import __TEMP_STORAGE__
 from collections import defaultdict
 from ..utils.miscellaneous import prettify_path, _attach_path, _FILE_MARKER
@@ -10,8 +9,10 @@ from ._cds_utils import retry_check_sum
 
 class StorageGCPCS:
     def __init__(self, carol, carolina):
+        import pandas as pd
         self.carol = carol
         self.carolina = carolina
+
 
         if not os.path.exists(__TEMP_STORAGE__):
             os.makedirs(__TEMP_STORAGE__)

--- a/setup.py
+++ b/setup.py
@@ -7,36 +7,33 @@ import sys
 
 here = os.path.abspath(os.path.dirname(__file__))
 
-install_requires = [
-    'pykube',
-    'click==7.0',
-    'dask[complete]',
-    'toolz',
-    'fastparquet',
-    'flask==1.0.2',
+min_requires = [
     'google-auth-httplib2',
     'google-auth',
     'google-cloud-core>=1.3.0',
     'google-cloud-storage',
-    'joblib==0.11',
-    'luigi',
-    'numpy==1.16.3',
-    'pandas==0.23.4',
+    'joblib>=0.11',
+    'numpy>=1.16.3',
+    'pandas>=0.23.4',
     'pyarrow>=0.15.1',
-    'redis==2.10.6',
     'requests',
     'tqdm',
     'urllib3',
     'deprecated',
-    'pytest',
-    'bumpversion',
     'python-dotenv',
-    'papermill',
-    'gcsfs>=0.3.0',
-    'dash',
-    'dash-cytoscape',
-    'colorcet',
+    'gcsfs>=0.3.0'
 ]
+
+extras_require = {
+    "pipeline": min_requires + ['luigi', 'papermill'],
+    "onlineapp": min_requires + ['flask>=1.0.2', 'redis'],
+    "dask": min_requires + ['dask[complete]'],
+    "dev": min_requires + ['pytest', 'bumpversion'],
+}
+extras_require["complete"] = sorted(
+    {v for req in extras_require.values() for v in req}
+)
+
 
 def read(*parts):
     # intentionally *not* adding an encoding option to open, See:
@@ -79,7 +76,8 @@ setup(
     author_email='ops@totvslabs.com',
     url='https://github.com/totvslabs/pyCarol',
     keywords=['Totvs', 'Carol.ai', 'AI'],
-    install_requires=install_requires,
+    install_requires=min_requires,
+    extras_require=extras_require,
     classifiers=[
         # Chose either "3 - Alpha", "4 - Beta" or "5 - Production/Stable" as the current state of your package
         'Development Status :: 5 - Production/Stable',

--- a/setup.py
+++ b/setup.py
@@ -7,15 +7,12 @@ import sys
 
 here = os.path.abspath(os.path.dirname(__file__))
 
+
 min_requires = [
     'google-auth-httplib2',
     'google-auth',
     'google-cloud-core>=1.3.0',
     'google-cloud-storage',
-    'joblib>=0.11',
-    'numpy>=1.16.3',
-    'pandas>=0.23.4',
-    'pyarrow>=0.15.1',
     'requests',
     'tqdm',
     'urllib3',
@@ -25,7 +22,9 @@ min_requires = [
 ]
 
 extras_require = {
-    "pipeline": min_requires + ['luigi', 'papermill'],
+    "dataframe": min_requires + [ 'pandas>=0.23.4', 'numpy>=1.16.3', 'joblib>=0.11', 'pyarrow>=0.15.1'],
+    "pipeline": min_requires + ['luigi', 'papermill', 'pandas>=0.23.4', 'numpy>=1.16.3', 'joblib>=0.11',
+                                'pyarrow>=0.15.1',],
     "onlineapp": min_requires + ['flask>=1.0.2', 'redis'],
     "dask": min_requires + ['dask[complete]'],
     "dev": min_requires + ['pytest', 'bumpversion'],


### PR DESCRIPTION
#### Please provide details about this Pull Request (why the change is being made, what this commit will do):
We have many dependencies in pycarol. But if one only wants to use staging/dm apis I dont need to have Luigi, tornado, flask installed. 
I added more options to install.
e.g., `pip install pycarol[pipeline]` this will install Luigi too. 
`pip install pycarol[dask,pipeline]` this will install dask and Luigi. 

The light version now is much faster to install. 

Question: which version should we send to docker hub? complete?


PS:
I will create a second PR to remove imports in "global" level, that could break this. I am working with desk. 
