### PR TITLE
Switch org

### DIFF
--- a/pycarol/auth/ApiKeyAuth.py
+++ b/pycarol/auth/ApiKeyAuth.py
@@ -51,7 +51,7 @@ class ApiKeyAuth:
 
         """
 
-        path = f'v2/oauth2/switchOrgContext/{org_id}'
+        path = f'v2/oauth2/switchOrgContextWithApiKey/{org_id}'
         resp = self.carol.call_api(method='POST', path=path)
 
         self.api_key = resp['apiKey']

--- a/pycarol/auth/PwdKeyAuth.py
+++ b/pycarol/auth/PwdKeyAuth.py
@@ -1,9 +1,9 @@
 import types
 import time
-from .PwdAuth_cloner import PwdAuthCloner
+from .PwdAuth import PwdAuth
 
 
-class PwdKeyAuth:
+class PwdKeyAuth(PwdAuth):
     """
 
     Args:
@@ -22,8 +22,6 @@ class PwdKeyAuth:
         self.connector_id = None
         self.lazy_login = lazy_login
 
-    def set_connector_id(self, connector_id):
-        self.connector_id = connector_id
 
     def login(self, carol):
         """
@@ -49,16 +47,9 @@ class PwdKeyAuth:
         resp = self.carol.call_api(f'v2/oauth2/token/{self.access_token}', method='GET', auth=False,
                                    content_type='application/x-www-form-urlencoded')
 
-        self._token = types.SimpleNamespace()
-        self._token.access_token = resp['access_token']
-        self._token.refresh_token = resp['refresh_token']
-        self._token.expiration = resp['timeIssuedInMillis'] + (
-                    resp['expires_in'] * 1000)
+        self._set_token(resp)
         if self.carol.verbose:
             print("Token: {}".format(self._token.access_token))
-
-    def authenticate_request(self, headers):
-        headers['Authorization'] = self.get_access_token()
 
     def _is_token_expired(self):
         if self._token is None:
@@ -73,63 +64,3 @@ class PwdKeyAuth:
         expiry = self._token.expiration - 60000
 
         return now > expiry
-
-    def get_access_token(self):
-        if self._is_token_expired():
-            self._refresh_token()
-
-        return self._token.access_token
-
-    def _refresh_token(self):
-        resp = self.carol.call_api('v2/oauth2/token', auth=False, data={
-            'grant_type': 'refresh_token',
-            'refresh_token': self._token.refresh_token
-        }, content_type='application/x-www-form-urlencoded')
-
-        self._token = types.SimpleNamespace()
-        self._token.access_token = resp['access_token']
-        self._token.refresh_token = resp['refresh_token']
-        self._token.expiration = resp['timeIssuedInMillis'] \
-                                 + (resp['expires_in'] * 1000)
-
-    def switch_context(self, env_id):
-        """
-        Switch context to an environment within the same organization.
-
-        Args:
-            env_id: environment id to switch context to.
-
-        Returns:
-            None
-
-        """
-
-        path = f'v2/oauth2/switchTenantContext/{env_id}'
-        resp = self.carol.call_api(method='POST', path=path)
-
-        self._token = types.SimpleNamespace()
-        self._token.access_token = resp['access_token']
-        self._token.refresh_token = resp['refresh_token']
-        self._token.expiration = resp['timeIssuedInMillis'] \
-                                 + (resp['expires_in'] * 1000)
-
-    def switch_org_context(self, org_id):
-        """
-        Go to the organization context or switch organization.
-
-        Args:
-            org_id: organization id.
-
-        Returns:
-            None
-
-        """
-
-        path = f'v2/oauth2/switchOrgContext/{org_id}'
-        resp = self.carol.call_api(method='POST', path=path)
-
-        self._token = types.SimpleNamespace()
-        self._token.access_token = resp['access_token']
-        self._token.refresh_token = resp['refresh_token']
-        self._token.expiration = resp['timeIssuedInMillis'] + (
-                resp['expires_in'] * 1000)

--- a/pycarol/carol.py
+++ b/pycarol/carol.py
@@ -113,6 +113,7 @@ class Carol:
         self.app_name = app_name
         self.port = port
         self.verbose = verbose
+        self._host_string = host
         self.host = self._set_host(domain=self.domain, organization=self.organization,
                                    environment=self.environment, host=host)
         self._tenant = None
@@ -123,6 +124,7 @@ class Carol:
         self.response = None
 
         self.org = None
+
 
 
     @property
@@ -402,9 +404,15 @@ class Carol:
         else:
             raise Exception("Auth object not set. Can't fetch token.")
 
-    def switch_environment(self, env_name=None, env_id=None, app_name=None):
+    def switch_org_level(self):
+
+        org = self._current_org()
+        self.auth.switch_org_context(org['mdmId'])
+
+    def switch_environment(self, env_name=None, env_id=None, app_name=None, org_name=None, org_id=None):
         """
-        Switch environments. If the user has access to this environment, it will be "logged in" in this new environment.
+        Switch org/environments. If the user has access to this environment, it will be "logged in" in this new
+        org/environment.
 
         Args:
 
@@ -415,6 +423,10 @@ class Carol:
             app_name: `str` default `None`
                 App name in the target environment to switch the context to.
                 Only needed with using CDS.
+            org_name: `str` default `None`
+                The organization name to switch context to. If the same keep it `None`
+            org_id: `str` default `None`
+                The organization id to switch context to. If the same keep it `None`
 
         Returns:
             self
@@ -435,6 +447,14 @@ class Carol:
         if self.org is None:
             self.org = Organization(self).get_organization_info(self.organization)
 
+        if org_id is not None or org_name is not None:
+            # Switch to org context.
+            self.switch_org_level()
+            if org_id is None:
+                org_id = Organization(self).get_organization_info(org_name)['mdmId']
+            # Switch org.
+            self.auth.switch_org_context(org_id)
+
         if env_name:
             env_id = Tenant(self).get_tenant_by_domain(env_name)['mdmId']
         elif env_id is None:
@@ -444,11 +464,15 @@ class Carol:
 
         self.domain = env_name
         self.app_name = app_name # TODO: Today we cannot use CDS without a valid app name.
-        self._tenant = Tenant(self).get_tenant_by_domain(env_name)
+        self._tenant = self._current_env()['mdmName']
+        self.organization = self._current_org()['mdmName']
+
+        self.host = self._set_host(domain=self.domain, organization=self.organization,
+                                   environment=self.environment, host=self._host_string)
 
         return self
 
-    def switch_context(self, env_name=None, env_id=None, org_name=None, org_id=None, app_name=None):
+    def switch_context(self, env_name=None, env_id=None, app_name=None, org_name=None, org_id=None):
         """
         Context manager to temporary have access to a second environment
 
@@ -481,43 +505,72 @@ class Carol:
         if self.org is None:
             self.org = Organization(self).get_organization_info(self.organization)
 
-        current_state = self.get_current()
-
         if env_name:
             env_id = Tenant(self).get_tenant_by_domain(env_name)['mdmId']
         elif env_id is None:
             raise ValueError('Either `env_name` or `env_id` must be set.')
 
-        if org_name:
-            org_id = Organization(self).get_organization_info(org_name)['mdmId']
-
         class SwitchContext(object):
 
-            def __init__(self, parent_context, env_name=None, env_id=None, org_id=None, app_name=None):
+            def __init__(self, parent_context, env_name=None, env_id=None, org_id=None, org_name=None, app_name=None):
                 self.parent_context = parent_context
                 self.env_name = env_name
                 self.env_id = env_id
                 self.app_name = app_name
                 self.org_id = org_id
+                self.org_name = org_name
 
             def __enter__(self):
                 self.parent_context.switch_environment(env_name=self.env_name, env_id=self.env_id,
-                                                       app_name=self.app_name)
+                                                       app_name=self.app_name, org_name=self.org_name,
+                                                       org_id=self.org_id)
                 return self.parent_context
 
             def __exit__(self, exc_type, exc_val, exc_tb):
                 del self.parent_context
 
-        return SwitchContext(parent_context=copy.deepcopy(self), env_name=env_name, env_id=env_id, app_name=app_name)
+        return SwitchContext(parent_context=copy.deepcopy(self), env_name=env_name, env_id=env_id, app_name=app_name,
+                             org_name=org_name, org_id=org_id,)
 
-    def get_current(self):
 
-        env = self.call_api('v2/tenants/current')
-        org = self.call_api('v1/organizations/current')
+    def _current_env(self):
+        return self.call_api('v1/tenants/current')
+
+    def _current_org(self):
+        return self.call_api('v1/organizations/current')
+
+    def get_current(self, level='all'):
+        """
+        Get current org/env information.
+
+        Args:
+
+            level: `str`:
+                Possible Values:
+                    "all": To get organization and environment information.
+                    "org": To get organization information.
+                    "env": To get environment information.
+
+        Returns: `dict`
+            Dictionary with keys org_Id, org_name, env_id, env_name
+
+        """
+
+        env = {}
+        org = {}
+
+        if level.lower() not in ['org', 'env', 'all']:
+            raise ValueError(f"level should be 'all', 'org', 'env', {level} was passed.")
+
+        if level.lower() == 'env' or level.lower() == 'all':
+            env = self._current_env()
+
+        if level.lower() == 'org' or level.lower() == 'all':
+            org = self._current_org()
 
         return {
-            "env_name": env['mdmName'],
-            "env_id": env['mdmId'],
-            "org_name": org['mdmName'],
-            "org_id": org['mdmId'],
+            "env_name": env.get('mdmName'),
+            "env_id": env.get('mdmId'),
+            "org_name": org.get('mdmName'),
+            "org_id": org.get('mdmId'),
         }


### PR DESCRIPTION
#### Please provide details about this Pull Request (why the change is being made, what this commit will do):
We have the switch context for Envs, now for org too. This allows us from one env/org get credentials for a second org/env that my user has access too. 

Similar to this
https://github.com/totvslabs/pyCarol/pull/443


```python
from pycarol import Carol

carol = Carol('tenantA', 'teste', auth=PwdAuth('rafael.rui@totvs.com.br', 'password'), organization='orgA' )

#inplace change here
carol.switch_environment(env_name='tenantB', org_name='orgB' )
print(carol.get_current())


carol = Carol('tenantA', 'teste', auth=PwdAuth('rafael.rui@totvs.com.br', 'password'), organization='orgA' )

with carol.switch_context('tenantB', org_name='orgB') as carol_orgB:
    print(carol_orgB.get_current()) # carol_orgB is the Carol() object logged in `tenantB` and `orgB` 


#back to `tenantA` and `orgA`
```

This works for APIKeys too. 
PS: Waiting to a Carol platform update to be able to use `APIKeys`. There is an API that needs to be updated. 