### PR TITLE
bug: function setting wrong values. 

### DIFF
--- a/pycarol/carol.py
+++ b/pycarol/carol.py
@@ -464,7 +464,7 @@ class Carol:
 
         self.domain = env_name
         self.app_name = app_name # TODO: Today we cannot use CDS without a valid app name.
-        self._tenant = self._current_env()['mdmName']
+        self._tenant = self._current_env()
         self.organization = self._current_org()['mdmName']
 
         self.host = self._set_host(domain=self.domain, organization=self.organization,


### PR DESCRIPTION
#### Please provide details about this Pull Request (why the change is being made, what this commit will do):
One method was setting the wrong value to the tenant variable. This was breaking when using switch context + CDs. 


