### PR TITLE
fix: Organization is not sending Auth information.

### DIFF
--- a/pycarol/organization.py
+++ b/pycarol/organization.py
@@ -9,31 +9,39 @@ class Organization:
     """
 
     def __init__(self, carol):
-
         self.carol = carol
 
-    def get_organization_info(self, organization):
+    def get_organization_info(self, organization, auth=True):
         """
-        Get organization information.
 
-        :param organization: `str`
-            Organization subdomain
-        :return:
-            dict with the information about the organization.
+        Args:
+            organization: `str`
+                Organization subdomain
+            auth: `bool`
+            If send the auth information. Some fields do not come if not logged.
+
+        Returns:
+             dict with the information about the organization.
+
         """
 
         return self.carol.call_api(f'v1/organizations/domain/{organization}',
-                                   auth=False, status_forcelist=[], retries=0)
+                                   auth=auth, status_forcelist=[], retries=0)
 
-
-    def get_environment_info(self, environment):
+    def get_environment_info(self, environment, auth=True):
         """
         Get environment information.
 
-        :param environment: `str`
-            Tenant name
-        :return:
+        Args:
+            environment: `str`
+                Tenant name
+            auth: `bool`
+                If send the auth information. Some fields do not come if not logged.
+
+        Returns:
             dict with the information about the environment.
+
         """
+
         return self.carol.call_api(f'v2/tenants/domain/{environment}',
-                                   auth=False, status_forcelist=[], retries=0)
+                                   auth=auth, status_forcelist=[], retries=0)


### PR DESCRIPTION
#### Please provide details about this Pull Request (why the change is being made, what this commit will do):
These to Carol APIs changed behavior. They used to work without authentication, now, if one sends without tokens we dont received the response. When we implemented this in the past, we need to add this special flag for APIs that could be called without token. I added the parameter to send the token, otherwise, this will break some pycarol APIs. 


