### PR TITLE
fix: buildkite queue name

### DIFF
--- a/.buildkite/pipeline.sh
+++ b/.buildkite/pipeline.sh
@@ -6,7 +6,7 @@ steps:
   - label: ":python: build"
     command: make ci
     agents:
-      queue: "default"
+      queue: "general"
       dind: true
     timeout_in_minutes: 10
   - wait: ~
@@ -14,7 +14,7 @@ steps:
     command: make release
     branches: "*.*.*"
     agents:
-      queue: "default"
+      queue: "general"
       dind: true
     timeout_in_minutes: 15
 EOF


### PR DESCRIPTION
There was a change on Buildkite configuration where the `default` queue was removed, defaulting to `general` now.