### PR TITLE
fix: Missing metadata column in fetch from staging

### DIFF
--- a/pycarol/__init__.py
+++ b/pycarol/__init__.py
@@ -12,7 +12,7 @@ __TEMP_STORAGE__ = os.path.join(tempfile.gettempdir(), 'carolina/cache')
 
 __CONNECTOR_PYCAROL__ = 'f9953f6645f449baaccd16ab462f9b64'
 
-_CAROL_METADATA_STAGING = ['mdmCounterForEntity', 'mdmId', 'mdmLastUpdated',
+_CAROL_METADATA_STAGING = ['mdmCounterForEntity', 'mdmId', 'mdmLastUpdated', 'mdmCreated',
                            'mdmConnectorId', 'mdmDeleted']
 
 _CAROL_METADATA_GOLDEN = ['mdmApplicationIdMasterRecordId', 'mdmCounterForEntity', 'mdmCreated',  'mdmCrosswalk',


### PR DESCRIPTION
#### Please provide details about this Pull Request (why the change is being made, what this commit will do):
@poffo noticed that there was one missing column in fetch parquet for stagings. 

#### Please provide links to relevant Trello cards, Slab topics or support ticket:
