### PR TITLE
feat: set RLIMIT_AS based on cgroups

### DIFF
--- a/pycarol/__init__.py
+++ b/pycarol/__init__.py
@@ -3,6 +3,7 @@
 """
 
 import os
+import resource
 import tempfile
 
 __version__ = '2.41.1'
@@ -43,3 +44,12 @@ from .auth.PwdKeyAuth import PwdKeyAuth
 from .cds import CDSGolden, CDSStaging
 from .apps import Apps
 from .subscription import Subscription
+
+if os.path.isfile('/sys/fs/cgroup/memory/memory.limit_in_bytes'):
+    old_soft, old_hard = resource.getrlimit(resource.RLIMIT_AS)
+    with open('/sys/fs/cgroup/memory/memory.limit_in_bytes') as limit:
+        mem = int(limit.read())
+        print(
+            'Setting memory limit from cgroups: soft {}->{}; hard {}->{}'.format(old_soft, mem, old_hard, mem)
+        )
+        resource.setrlimit(resource.RLIMIT_AS, (mem, mem))


### PR DESCRIPTION
#### Please provide details about this Pull Request (why the change is being made, what this commit will do):

When running python inside a container, it sees the host memory instead of the resources it has been given, which may cause python to try to allocate more memory than it is allowed, and as a result Linux's oomkiller will kill its process.

This PR reads the `cgroups` memory limit file and sets its contents as both soft and hard limit for python, which should help with that.

PS: I'm not yet sure this is the right/best way of doing this.

#### Please provide links to relevant Trello cards, Slab topics or support ticket:

Similar PR on Jupyter: https://github.com/jupyter/notebook/pull/5876