### PR TITLE
feat: improve CarolAPI

### DIFF
--- a/pycarol/carol_api.py
+++ b/pycarol/carol_api.py
@@ -26,7 +26,7 @@ CAROL_KNOWN_MODULES = {
 }
 
 
-class CarolAPI:
+class CarolAPI(Carol):
     """Encapsulates some pycarol modules
 
     Args:
@@ -118,11 +118,14 @@ class CarolAPI:
     def __init__(self, domain=None, app_name=None, auth=None, connector_id=None, port=443, verbose=False,
                  organization=None, environment=None, host=None, user=None, password=None, api_key=None):
 
-        self.carol = Carol(domain=domain, app_name=app_name, auth=auth, connector_id=connector_id, port=port, verbose=verbose,
-                           organization=organization, environment=environment, host=host, user=user, password=password, api_key=api_key)
+        super(CarolAPI, self).__init__(domain=domain, app_name=app_name, auth=auth, connector_id=connector_id, port=port, verbose=verbose,
+                                       organization=organization, environment=environment, host=host, user=user, password=password, api_key=api_key)
+
         
         self._all_modules = set()
         self._create_context()
+
+        
 
     def _create_context(self):
 
@@ -143,8 +146,8 @@ class CarolAPI:
             allow_args (bool): use functools.partial to allow passing arguments when calling the module. 
         """
         if allow_args:
-            module = partial(module, self.carol)
+            module = partial(module, self)
             setattr(self, module_name, module)
         else:
-            setattr(self, module_name, module(self.carol))
+            setattr(self, module_name, module(self))
         self._all_modules.update([module_name])


### PR DESCRIPTION
#### Please provide details about this Pull Request (why the change is being made, what this commit will do):
@gzamboni 

Playing with eh context I realized that I can extend the Carol class to use this feature. 

We can then just do

```python
from pycarol import CarolAPI as Carol
```

and it would be compatible. I think it would be possible to add directly to Carol's class, but it could have some cyclic dependences in some modules. It is safer to isolate this. 