### PR TITLE
bug: returning dataframe when using bq and dataset if

### DIFF
--- a/pycarol/bigquery.py
+++ b/pycarol/bigquery.py
@@ -19,12 +19,14 @@ def query(
     carol: Carol,
     query_: str,
     service_account: T.Optional[T.Dict[str, str]] = None,
+    dataset_id: T.Optional[str] = None,
 ) -> QueryJob:
     """Run query for datamodel.
 
     Args:
         query_: BigQuery SQL query.
         service_account: in case you have a service account for accessing BigQuery.
+        dataset_id: BigQuery dataset ID.
 
     Returns:
         Query result.
@@ -35,7 +37,7 @@ def query(
     query_ = _prepare_query(carol, query_)
     client = _generate_client(service_account)
     tenant_id = carol.tenant["mdmId"]
-    dataset_id = f"labs-app-mdm-production.{tenant_id}"
+    dataset_id = dataset_id or f"labs-app-mdm-production.{tenant_id}"
     job_config = bigquery.QueryJobConfig(default_dataset=dataset_id)
     return client.query(query_, job_config=job_config)
 

--- a/pycarol/sql.py
+++ b/pycarol/sql.py
@@ -68,6 +68,7 @@ class SQL:
         method: str = "sync",
         dataframe: bool = True,
         service_account: T.Optional[T.Dict[str, str]] = None,
+        dataset_id: T.Optional[str] = None,
         **kw,
     ):
         """Execute SQL Query.
@@ -84,6 +85,7 @@ class SQL:
             dataframe: `bool` default `True`
                 if True returns a pandas dataframe
             service_account: in case you have a service account for accessing BigQuery.
+            dataset_id: overwrites the default dataset_id when using bigquery.
             **kw: `dict`
         Returns:
 
@@ -97,7 +99,7 @@ class SQL:
         elif method == "sync":
             results = _sync_query(self.carol, payload)
         elif method == "bigquery":
-            results = bigquery.query(self.carol, query, service_account)
+            results = bigquery.query(self.carol, query, service_account, dataset_id=dataset_id)
         else:
             raise ValueError(f"'method' must be either: {methods}")
 

--- a/pycarol/sql.py
+++ b/pycarol/sql.py
@@ -80,6 +80,7 @@ class SQL:
             method: `str` default `sync`
                 if sync runs the query synchronously and returns the result
                 if socket runs the query using web socket and returns the result
+                if bigquery runs the query using bigquery and returns the result
             dataframe: `bool` default `True`
                 if True returns a pandas dataframe
             service_account: in case you have a service account for accessing BigQuery.
@@ -100,10 +101,10 @@ class SQL:
         else:
             raise ValueError(f"'method' must be either: {methods}")
 
+        if method == "bigquery":
+            results = [dict(row) for row in results]
         if dataframe:
             return pd.DataFrame(results)
-        if not dataframe and method == "bigquery":
-            return [dict(row) for row in results]
 
         return results
 


### PR DESCRIPTION
#### Please provide details about this Pull Request (why the change is being made, what this commit will do):


#### Please provide links to relevant Trello cards, Slab topics or support ticket:
fixing https://github.com/totvslabs/pyCarol/issues/563 and
https://github.com/totvslabs/pyCarol/issues/564

for https://github.com/totvslabs/pyCarol/issues/564 you were using a sandbox, today carol does not provide an API to pycarol to solve the dataset ID, so I added a option to overwrite the default production dataset_id