### PR TITLE
big query query and SA generation

### DIFF
--- a/pycarol/bigquery.py
+++ b/pycarol/bigquery.py
@@ -1,18 +1,120 @@
 """Back-end for BigQuery-related code."""
 import re
+import copy
 import typing as T
+from datetime import datetime, timedelta
 
 from google.cloud import bigquery
 from google.cloud.bigquery.job.query import QueryJob
 from google.oauth2.service_account import Credentials
+try:
+    import pandas as pd
+except ImportError:
+    pass
 
 from .carol import Carol
 from .connectors import Connectors
 
 
-def get_service_account() -> T.Dict[str, str]:
-    """Get BigQuery credentials from Carol."""
-    ...
+class BQ:
+
+    token = None
+
+    def __init__(self, carol: Carol, service_account: dict = None):
+        self.carol = carol
+        self.service_account = service_account
+        self._provided_sa = service_account is not None
+        self.env = carol.get_current()
+        self.client = None
+        self.dataset_id = f"carol-{self.env['env_id'][0:20]}.{self.env['env_id']}"
+
+    def _generate_client(self) -> bigquery.Client:
+        """Generate client from credentials."""
+
+        if self._provided_sa:
+            service_account = self.service_account
+        else:
+            service_account = BQ.token['sa']
+
+        credentials = Credentials.from_service_account_info(service_account)
+        project = service_account["project_id"]
+        client = bigquery.Client(project=project, credentials=credentials)
+        return client
+
+    def is_expired(self):
+
+        if self._provided_sa:
+            return False
+        elif BQ.token is None and self.service_account is None:
+            return True
+        elif (BQ.token is not None) and ((BQ.token['expiration_time'] < datetime.utcnow()) or (BQ.token['env']['env_id'] != self.env['env_id'])):
+            return True
+        elif BQ.token is None:
+            return True
+        else:
+            return False
+
+    def get_credential(self, expiration_time: int = 120, force: bool = False) -> dict:
+        """ Get service account for BigQuery.
+
+        Args:
+            expiration_time (int): Time in hours for credentials to expire. Max value 120.
+            force (bool): Force to get new credentials.
+
+        Returns:
+            dict: Service account
+        """
+
+        if force or self.is_expired():
+            expiration_estimate = datetime.utcnow() + timedelta(hours=expiration_time)
+
+            url = 'v1/create_temporary_key'
+            prefix_path = '/sql/v1/api/'
+            env = self.carol.get_current()
+            payload = {
+                "expirationTime": expiration_time,
+                "mdmOrgId": env['org_id'],
+                "mdmTenantId":  env['env_id']
+            }
+            self.service_account = self.carol.call_api(
+                method='POST', path=url, prefix_path=prefix_path, data=payload)
+
+            BQ.token = {'sa': self.service_account,
+                        'expiration_time': expiration_estimate, 'env': copy.deepcopy(self.env)}
+
+        return self.service_account
+
+    def query(
+        self,
+        query: str,
+        dataset_id: T.Optional[str] = None,
+        return_dataframe: bool = True,
+    ):
+        """Run query for datamodel.
+
+        Args:
+            query: BigQuery SQL query.
+            dataset_id: BigQuery dataset ID.
+                if None it will use the default dataset_id.
+            return_dataframe: Return dataframe.
+                Return dataframe if True.
+
+        Returns:
+            Query result.
+        """
+
+        self.service_account = self.get_credential()
+        self.client = self._generate_client()
+
+        dataset_id = dataset_id or self.dataset_id
+        job_config = bigquery.QueryJobConfig(default_dataset=dataset_id)
+        results = self.client.query(query, job_config=job_config)
+
+        results = [dict(row) for row in results]
+        if return_dataframe:
+            return pd.DataFrame(results)
+        else:
+            return results
 
 
 def query(
@@ -32,14 +134,16 @@ def query(
         Query result.
     """
     if service_account is None:  # must call carol to get service account
-        raise NotImplementedError("You must pass a service_account. Not implemented.")
+        raise NotImplementedError(
+            "You must pass a service_account. Not implemented.")
 
     query_ = _prepare_query(carol, query_)
     client = _generate_client(service_account)
     tenant_id = carol.tenant["mdmId"]
     dataset_id = dataset_id or f"labs-app-mdm-production.{tenant_id}"
     job_config = bigquery.QueryJobConfig(default_dataset=dataset_id)
-    return client.query(query_, job_config=job_config)
+    results = client.query(query_, job_config=job_config)
+    return results
 
 
 def _prepare_query(
@@ -70,7 +174,8 @@ def _prepare_query(
         name: connectors.get_by_name(name)["mdmId"] for name in connector_names
     }
 
-    staging_vars = filter(lambda conn_name: conn_name[0] is not None, template_vars)
+    staging_vars = filter(
+        lambda conn_name: conn_name[0] is not None, template_vars)
     model_vars = filter(lambda conn_name: conn_name[0] is None, template_vars)
 
     replace_map = {}
@@ -92,7 +197,8 @@ def _prepare_query(
 def _generate_client(service_account: T.Dict[str, str]) -> bigquery.Client:
     """Generate client from credentials."""
     credentials = Credentials.from_service_account_info(service_account)
-    return bigquery.Client(project="labs-app-mdm-production", credentials=credentials)
+    project = service_account["project_id"]
+    return bigquery.Client(project=project, credentials=credentials)
 
 
 REGEX = re.compile(

--- a/pycarol/bigquery.py
+++ b/pycarol/bigquery.py
@@ -59,10 +59,21 @@ class BQ:
 
         Args:
             expiration_time (int): Time in hours for credentials to expire. Max value 120.
-            force (bool): Force to get new credentials.
+            force (bool): Force to get new credentials skiping any cache.
 
         Returns:
             dict: Service account
+
+        .. code:: python
+
+
+            from pycarol import Carol
+            from pycarol.bigquery import BQ
+
+            bq = BQ(Carol())
+            service_account = bq.get_credential(expiration_time=120)
+
+
         """
 
         if force or self.is_expired():
@@ -90,7 +101,7 @@ class BQ:
         dataset_id: T.Optional[str] = None,
         return_dataframe: bool = True,
     ):
-        """Run query for datamodel.
+        """Run query for datamodel. This will generate a SA if necessary.
 
         Args:
             query: BigQuery SQL query.
@@ -101,6 +112,19 @@ class BQ:
 
         Returns:
             Query result.
+
+        Usage:
+
+        .. code:: python
+
+
+            from pycarol import Carol
+            from pycarol.bigquery import BQ
+
+            bq = BQ(Carol())
+            query = 'select * from invoice limit 10'	
+            df = bq.query(query, return_dataframe=True)
+
         """
 
         self.service_account = self.get_credential()

--- a/pycarol/carol.py
+++ b/pycarol/carol.py
@@ -252,7 +252,7 @@ class Carol:
     def call_api(self, path, method=None, data=None, auth=True, params=None, content_type='application/json', retries=8,
                  session=None, backoff_factor=0.5, status_forcelist=(502, 503, 504, 524), downloadable=False,
                  method_whitelist=frozenset(['HEAD', 'TRACE', 'GET', 'PUT', 'OPTIONS', 'DELETE', 'POST']), errors='raise',
-                 extra_headers=None, files=None,
+                 extra_headers=None, files=None, prefix_path='/api/',
                  **kwds):
         """
         This method handles all the API calls.
@@ -294,6 +294,8 @@ class Carol:
                 extra headers to be sent.
             files: `dict` default `None`
                 Used when uploading files to carol. This will be sent to :class: `requests.request`
+            prefix_path: `str` default `/api/`
+                Prefix path to be used to create the final url 'https://{self.host}:{self.port}{prefix_path}{path}.
             kwds: `dict` default `None`
                 Extra parameters to be sent to :class: `requests.request`
 
@@ -305,7 +307,7 @@ class Carol:
             self.session = session
 
         extra_headers = extra_headers or {}
-        url = f'https://{self.host}:{self.port}/api/{path}'
+        url = f'https://{self.host}:{self.port}{prefix_path}{path}'
 
         if method is None:
             if data is None:


### PR DESCRIPTION
#### Please provide details about this Pull Request (why the change is being made, what this commit will do):
1. Allow users to create SA.
2. Cache system to avoid recreating  SAs. 

PS: I did not remove the old query process. We need to see if people are using it. I removed all the query preparation. First, because in the new big query the connector_name is the default prefix. Second, if anything changes in these definitions we need to change in pycarol. Let's wait for this feature to be more mature then we can add this.

Usage:

```python
  from pycarol import Carol
  from pycarol.bigquery import BQ

  bq = BQ(Carol())
  query = 'select * from invoice limit 10'	
  df = bq.query(query, return_dataframe=True)
```
No need to request a SA to use in query. pycarol will handle it.

But, if one wants
```python
  from pycarol import Carol
  from pycarol.bigquery import BQ

  bq = BQ(Carol())
  service_account = bq.get_credential(expiration_time=120)
```