### PR TITLE
fix: SCHEMA_TYPES for NumPy versions >= 1.20

### DIFF
--- a/pycarol/schema_generator.py
+++ b/pycarol/schema_generator.py
@@ -42,6 +42,10 @@ class Type(object):
 
         """docstring for get_schema_type_for"""
 
+        if np.__version__.startswith("1.2"):
+            np.int = np.int64
+            np.float = np.float64
+
         SCHEMA_TYPES = {
             type(None): NullType,
             str: StringType,


### PR DESCRIPTION
As discussed in issue #607, an error is raised when trying to send a staging table to Carol.

This happens because NumPy versions >= 1.20 no longer use the np.int or np.float types.

This commit suggests a solution to ensure that the types work in both versions <1.20 and >=1.20.

The change will check the NumPy version and, if it is greater than or equal to 1.20, replace np.int and np.float with np.int64 and np.float64.

Open issue: #607