### PR TITLE
fix: rolling back to allow for all urllib3 versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ min_requires = [
     "requests",
     "retry",
     "tqdm",
-    "urllib3==2.0.4",
+    "urllib3",
 ]
 
 dataframe_requires = [


### PR DESCRIPTION
#### Please provide details about this Pull Request (why the change is being made, what this commit will do):
The first fix forced urllib3 version which may impact developers that do not set their version for pycarol. This new solution allow for all versions without fixing any versions.

#### Please provide links to relevant Trello cards, Slab topics or support ticket:
https://totvslabs.atlassian.net/browse/DASC-1272