### PR TITLE
feat: add labels to bigquery job

### DIFF
--- a/test/test_bigquery.py
+++ b/test/test_bigquery.py
@@ -134,12 +134,30 @@ def test_bq_init(manager_mock) -> None:
     """Test the initialization of the BQ class in the pycarol.bigquery module."""
     bq_mock = mock.MagicMock()
     carol_mock = mock.MagicMock()
-    carol_mock.get_current.return_value = {"env_id": "5"}
+    carol_mock.app_name = " "
+    carol_mock.get_current.return_value = {'env_name': 'env_name',
+                                           'env_id': 'env_id',
+                                           'org_name': 'org_name',
+                                           'org_id': 'org_id',
+                                           'org_level': False}
     pycarol.bigquery.BQ.__init__(bq_mock, carol_mock)
-    assert bq_mock._env == {"env_id": "5"}
-    assert bq_mock._project_id == "carol-5"
-    assert bq_mock._dataset_id == "carol-5.5"
+    assert bq_mock._env == {'env_name': 'env_name',
+                            'env_id': 'env_id',
+                            'org_name': 'org_name',
+                            'org_id': 'org_id',
+                            'org_level': False,
+                            'app_name': ' '}
+    assert bq_mock._project_id == "carol-env_id"
+    assert bq_mock._dataset_id == "carol-env_id.env_id"
     assert bq_mock._token_manager == manager_mock.return_value
+    assert pycarol.bigquery.BQ._build_query_job_labels(bq_mock) == {
+        'tenant_id': 'env_id',
+        'tenant_name': 'env_name',
+        'organization_id': 'org_id',
+        'organization_name': 'org_name',
+        'job_type': 'sync',
+        'source': 'py_carol'
+    }
 
 
 @mock.patch("pycarol.bigquery.Credentials")


### PR DESCRIPTION
#### Please provide details about this Pull Request (why the change is being made, what this commit will do):
The PR adds labels to the BigQuery.JobConfig in order to help us understand the job's performances better and enable new segmentation strategies for the Carol Apps.

#### Please provide links to relevant Trello cards, Slab topics or support tickets:
https://totvslabs.atlassian.net/browse/DASC-1208?atlOrigin=eyJpIjoiOWZhZTc4ZDViYmUxNDhlNmIyNWVkOGY4YWRmNTc0ZjciLCJwIjoiaiJ9

#### Attention Points
- Although the behaviour of the `BQ.query` function has not changed in a production test. I was unable to verify that the labels were added to the BigQuery job because I don't have access to the tables. Maybe there is another way to check this in production, but I couldn't find it.
- I added some doubts in the code to check if my decision was correct for the respective labels.