### PR TITLE
Dasc 1208/add labels to bq job config

### DIFF
--- a/pycarol/bigquery.py
+++ b/pycarol/bigquery.py
@@ -242,7 +242,7 @@ class BQ:
         cache_cds: bool = True,
     ):
         self._env = carol.get_current()
-        self._env['app_name'] = carol.app_name
+        self._env["app_name"] = carol.app_name
         self._project_id = f"carol-{self._env['env_id'][0:20]}"
         self._dataset_id = f"{self._project_id}.{self._env['env_id']}"
         self._token_manager = TokenManager(carol, service_account, cache_cds)
@@ -257,28 +257,28 @@ class BQ:
 
     def _build_query_job_labels(self) -> T.Dict[str, str]:
         label_values = [
-            self._env.get('env_id', ''),
-            self._env.get('env_name', ''),
-            self._env.get('org_id', ''),
-            self._env.get('org_name', ''),
+            self._env.get("env_id", ""),
+            self._env.get("env_name", ""),
+            self._env.get("org_id", ""),
+            self._env.get("org_name", ""),
             "sync",
             "py_carol",
             "",
-            self._env.get('app_name', ''),
-            ""
+            self._env.get("app_name", ""),
+            "",
         ]
         label_keys = [
             "tenant_id",
             "tenant_name",
             "organization_id",
             "organization_name",
-            "job_type", ## Is any case that using this class is async?
+            "job_type",  ## Is any case that using this class is async?
             "source",
-            "task_id", ## In this case may we use the "mdmBigQueryProvisionId" from 'carol._current_env()'?
+            "task_id",  ## In this case may we use the "mdmBigQueryProvisionId" from 'carol._current_env()'?
             "carol_app_name",
-            "carol_app_process_name", ## I do not understand what should be this property
-            ]
-        return {k:v for k,v in zip(label_keys, label_values) if v.strip() != ""}
+            "carol_app_process_name",  ## I do not understand what should be this property
+        ]
+        return {k: v for k, v in zip(label_keys, label_values) if v.strip() != ""}
 
     def query(
         self,
@@ -349,7 +349,7 @@ class BQ:
 
         if return_job_id:
             return (pandas.DataFrame(results), results_job.job_id)
-        
+
         return pandas.DataFrame(results)
 
 
@@ -447,7 +447,11 @@ class BQStorage:
         service_account = self._token_manager.get_token().service_account
         client = self._generate_client(service_account)
         read_session = self._get_read_session(
-            client, table_name, columns_names, row_restriction, sample_percentage,
+            client,
+            table_name,
+            columns_names,
+            row_restriction,
+            sample_percentage,
         )
 
         stream = read_session.streams[0]

--- a/pycarol/bigquery.py
+++ b/pycarol/bigquery.py
@@ -5,6 +5,7 @@ import json
 from pathlib import Path
 import sys
 import typing as T
+import os
 
 from google.cloud import bigquery, bigquery_storage, bigquery_storage_v1
 from google.cloud.bigquery_storage import types
@@ -256,29 +257,18 @@ class BQ:
         return client
 
     def _build_query_job_labels(self) -> T.Dict[str, str]:
-        label_values = [
-            self._env.get("env_id", ""),
-            self._env.get("env_name", ""),
-            self._env.get("org_id", ""),
-            self._env.get("org_name", ""),
-            "sync",
-            "py_carol",
-            "",
-            self._env.get("app_name", ""),
-            "",
-        ]
-        label_keys = [
-            "tenant_id",
-            "tenant_name",
-            "organization_id",
-            "organization_name",
-            "job_type",  ## Is any case that using this class is async?
-            "source",
-            "task_id",  ## In this case may we use the "mdmBigQueryProvisionId" from 'carol._current_env()'?
-            "carol_app_name",
-            "carol_app_process_name",  ## I do not understand what should be this property
-        ]
-        return {k: v for k, v in zip(label_keys, label_values) if v.strip() != ""}
+        labels_to_check = {
+            "tenant_id": self._env.get("env_id", ""),
+            "tenant_name": self._env.get("env_name", ""),
+            "organization_id": self._env.get("org_id", ""),
+            "organization_name": self._env.get("org_name", ""),
+            "job_type": "sync",
+            "source": "py_carol",
+            "task_id": os.environ.get("LONGTAKSID", ""),
+            "carol_app_name": self._env.get("app_name", ""),
+            "carol_app_process_name": os.environ.get("ALGORITHM_NAME", ""),
+        }
+        return {k: v for k, v in labels_to_check.items() if v.strip() != ""}
 
     def query(
         self,

--- a/test/test_bigquery.py
+++ b/test/test_bigquery.py
@@ -135,28 +135,32 @@ def test_bq_init(manager_mock) -> None:
     bq_mock = mock.MagicMock()
     carol_mock = mock.MagicMock()
     carol_mock.app_name = " "
-    carol_mock.get_current.return_value = {'env_name': 'env_name',
-                                           'env_id': 'env_id',
-                                           'org_name': 'org_name',
-                                           'org_id': 'org_id',
-                                           'org_level': False}
+    carol_mock.get_current.return_value = {
+        "env_name": "env_name",
+        "env_id": "env_id",
+        "org_name": "org_name",
+        "org_id": "org_id",
+        "org_level": False,
+    }
     pycarol.bigquery.BQ.__init__(bq_mock, carol_mock)
-    assert bq_mock._env == {'env_name': 'env_name',
-                            'env_id': 'env_id',
-                            'org_name': 'org_name',
-                            'org_id': 'org_id',
-                            'org_level': False,
-                            'app_name': ' '}
+    assert bq_mock._env == {
+        "env_name": "env_name",
+        "env_id": "env_id",
+        "org_name": "org_name",
+        "org_id": "org_id",
+        "org_level": False,
+        "app_name": " ",
+    }
     assert bq_mock._project_id == "carol-env_id"
     assert bq_mock._dataset_id == "carol-env_id.env_id"
     assert bq_mock._token_manager == manager_mock.return_value
     assert pycarol.bigquery.BQ._build_query_job_labels(bq_mock) == {
-        'tenant_id': 'env_id',
-        'tenant_name': 'env_name',
-        'organization_id': 'org_id',
-        'organization_name': 'org_name',
-        'job_type': 'sync',
-        'source': 'py_carol'
+        "tenant_id": "env_id",
+        "tenant_name": "env_name",
+        "organization_id": "org_id",
+        "organization_name": "org_name",
+        "job_type": "sync",
+        "source": "py_carol",
     }
 
 

--- a/test/test_bigquery.py
+++ b/test/test_bigquery.py
@@ -134,12 +134,30 @@ def test_bq_init(manager_mock) -> None:
     """Test the initialization of the BQ class in the pycarol.bigquery module."""
     bq_mock = mock.MagicMock()
     carol_mock = mock.MagicMock()
-    carol_mock.get_current.return_value = {"env_id": "5"}
+    carol_mock.app_name = " "
+    carol_mock.get_current.return_value = {'env_name': 'env_name',
+                                           'env_id': 'env_id',
+                                           'org_name': 'org_name',
+                                           'org_id': 'org_id',
+                                           'org_level': False}
     pycarol.bigquery.BQ.__init__(bq_mock, carol_mock)
-    assert bq_mock._env == {"env_id": "5"}
-    assert bq_mock._project_id == "carol-5"
-    assert bq_mock._dataset_id == "carol-5.5"
+    assert bq_mock._env == {'env_name': 'env_name',
+                            'env_id': 'env_id',
+                            'org_name': 'org_name',
+                            'org_id': 'org_id',
+                            'org_level': False,
+                            'app_name': ' '}
+    assert bq_mock._project_id == "carol-env_id"
+    assert bq_mock._dataset_id == "carol-env_id.env_id"
     assert bq_mock._token_manager == manager_mock.return_value
+    assert pycarol.bigquery.BQ._build_query_job_labels(bq_mock) == {
+        'tenant_id': 'env_id',
+        'tenant_name': 'env_name',
+        'organization_id': 'org_id',
+        'organization_name': 'org_name',
+        'job_type': 'sync',
+        'source': 'py_carol'
+    }
 
 
 @mock.patch("pycarol.bigquery.Credentials")


### PR DESCRIPTION
#### Please provide details about this Pull Request (why the change is being made, what this commit will do):
The PR adds labels to the BigQuery.JobConfig in order to help us understand the job's performances better and enable new segmentation strategies for the Carol Apps.

#### Please provide links to relevant Trello cards, Slab topics or support tickets:
https://totvslabs.atlassian.net/browse/DASC-1208?atlOrigin=eyJpIjoiOWZhZTc4ZDViYmUxNDhlNmIyNWVkOGY4YWRmNTc0ZjciLCJwIjoiaiJ9

#### QA
![image](https://github.com/totvslabs/pyCarol/assets/24700707/cb83c2c3-2273-4268-82fd-50b1bb2e2a60)

#### Attention Points
- ~Although the behaviour of the `BQ.query` function has not changed in a production test. I was unable to verify that the labels were added to the BigQuery job because I don't have access to the tables. Maybe there is another way to check this in production, but I couldn't find it.~
- ~I added some doubts in the code to check if my decision was correct for the respective labels.~
