### PR TITLE
Requirements review and BigQuery ServiceAccount checking improvements.

### DIFF
--- a/pycarol/bigquery.py
+++ b/pycarol/bigquery.py
@@ -335,7 +335,7 @@ class BQ:
         labels = self._build_query_job_labels()
         job_config = bigquery.QueryJobConfig(default_dataset=dataset_id, labels=labels)
 
-        if self._token_manager.get_token().expired(backoff_seconds=(1*60*60)): # 1 hour
+        if self._token_manager.get_token().expired(backoff_seconds=(1*60*30)): # 30 minutes
             service_account = self._token_manager.get_forced_token().service_account
             client = self._generate_client(service_account)
             self._validate_client(client, retry=5)

--- a/setup.py
+++ b/setup.py
@@ -22,11 +22,11 @@ min_requires = [
     "retry",
     "tqdm",
     "urllib3",
+    "pandas>=0.23.4,!=1.0.4",
+    "numpy>=1.16.3",
 ]
 
 dataframe_requires = [
-    "pandas>=0.23.4,!=1.0.4",
-    "numpy>=1.16.3",
     "joblib>=0.11",
     "pyarrow>=0.15.1,<1.0.0",
 ]

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ min_requires = [
     "urllib3",
     "pandas>=0.23.4,!=1.0.4",
     "numpy>=1.16.3",
+    "pip-system-certs"
 ]
 
 dataframe_requires = [


### PR DESCRIPTION
Jira Issue: https://totvsideia.atlassian.net/browse/DAEN-6225 
Jira issue: https://totvsideia.atlassian.net/browse/DAEN-6225

- Added pandas and numpy as minimum requirements. 
Since pycarol is most used for data manipulation using BigQuery and pandas nowadays, pandas and numpy are being treated now as minimum requirements starting from this version. This avoids the necessity of importing pandas alongside with pycarol and avoids errors because pandas was not imported.

- Added pip-system-certs as minimum requirements. 
This is to prevent SSL errors on DOS based terminals (e.g. powershell or command prompt).

- Added service account checking inside query method.
Recently we were facing JWT errors when using BigQuery interfaces with Service Accounts that have expired while the BQ object was still instanciated, making some requests fail mid process. This can happen due to BigQuery queue times or expensive queries, making the request take several minutes. We added a checking on query method that validades if the service account has a TTL greater than 30 minutes, ensuring the object will have valid credentials when querying BigQuery.
